### PR TITLE
Generate AppImage on Travis CI for each git push, closes #22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+  - sudo add-apt-repository ppa:beineri/opt-qt593-trusty -y
+  - sudo apt-get update -qq
+
+install:
+  - sudo apt-get -y install qt59base libusb-1.0-0-dev
+  - source /opt/qt*/bin/qt*-env.sh
+
+script:
+  - cd Desktop_Interface
+  - qmake CONFIG+=release PREFIX=/usr
+  - make -j$(nproc)
+# - make INSTALL_ROOT=appdir -j$(nproc) install ; find appdir/
+#   NOTE: The following 5 lines should not be needed if "make install" would be made work for Labrador; see
+#   https://github.com/probonopd/linuxdeployqt#using-linuxdeployqt-with-travis-ci
+  - sudo cp ./build_linux/libdfuprog/lib/x64/libdfuprog-*.so /usr/lib/x86_64-linux-gnu/ # FIXME
+  - mkdir -p appdir/usr/bin/ ; ldd bin/Labrador ; strip bin/Labrador ; cp bin/Labrador appdir/usr/bin/
+  - cp -r bin/{waveforms,firmware}  appdir/usr/bin/
+  - mkdir -p appdir/usr/share/applications ; cp build_linux/labrador.desktop appdir/usr/share/applications
+  - mkdir -p appdir/usr/share/icons/hicolor/256x256/apps/ ; cp '../build_scripts/linux deploy labra 64-bit/labradeb/usr/share/app-install/icons/espotek-labrador.png' appdir/usr/share/icons/hicolor/256x256/apps/
+  - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
+  - ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -verbose=2
+  - ./linuxdeployqt*.AppImage --appimage-extract
+  - rm ./appdir/AppRun ; cp ./build_linux/AppRun appdir/ ; chmod a+x ./appdir/AppRun # Replace symlink with custom script
+  - PATH=./squashfs-root/usr/bin:$PATH ./squashfs-root/usr/bin/appimagetool -g ./appdir/
+
+after_success:
+  - find appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - # curl --upload-file EspoTek_Labrador*.AppImage https://transfer.sh/EspoTek_Labrador-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh EspoTek_Labrador*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/

--- a/Desktop_Interface/build_linux/AppRun
+++ b/Desktop_Interface/build_linux/AppRun
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+
+cat > /tmp/roothelper <<\EOoF
+#!/bin/bash
+cat > /etc/udev/rules.d/69-labrador.rules <<\EOF
+ENV{ID_VENDOR_ID}=="03eb", ENV{ID_MODEL_ID}=="ba94", SYMLINK="EspoTek_Labrador", MODE="0666"
+ENV{ID_VENDOR_ID}=="03eb", ENV{ID_MODEL_ID}=="2fe4", SYMLINK="ATXMEGA32A4U DFU Bootloader", MODE="0666"
+EOF
+udevadm trigger
+EOoF
+chmod a+x /tmp/roothelper
+
+sudo true && sudo /tmp/roothelper
+sudo true || pkexec --disable-internal-agent /tmp/roothelper || true
+
+rm /tmp/roothelper
+
+exec "$HERE/usr/bin/Labrador" "$@"

--- a/Desktop_Interface/build_linux/labrador.desktop
+++ b/Desktop_Interface/build_linux/labrador.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=EspoTek Labrador
+Comment=Software Interface for Labrador Board
+Exec=Labrador 
+Terminal=false
+Type=Application
+Categories=Development;Electronics;
+Icon=espotek-labrador


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/apps) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so. Also, You need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.
If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.