### PR TITLE
isoBufferBuffer refactor

### DIFF
--- a/Desktop_Interface/isobufferbuffer.cpp
+++ b/Desktop_Interface/isobufferbuffer.cpp
@@ -1,5 +1,7 @@
 #include "isobufferbuffer.h"
 
+#include <QDebug>
+
 /* isoBufferBuffer is implemented as two consecutive, duplicate,
  * ring buffers. the effect of this is that we are able to hand
  * out pointers to pieces of contiguous memory representing the

--- a/Desktop_Interface/isobufferbuffer.cpp
+++ b/Desktop_Interface/isobufferbuffer.cpp
@@ -34,7 +34,7 @@ uint32_t isoBufferBuffer::capacity () const {
 
 
 // Legacy Interface Implementation
-void isoBufferBuffer::add(std::string newString)
+void isoBufferBuffer::add(std::string const & newString)
 {
     for (char newChar : newString)
         insert(newChar);

--- a/Desktop_Interface/isobufferbuffer.cpp
+++ b/Desktop_Interface/isobufferbuffer.cpp
@@ -28,89 +28,100 @@
 // 2. adjust the size of the requested buffer to accomodate
 // the improved memory efficiency of the new algorithm
 
-isoBufferBuffer::isoBufferBuffer (
-	uint32_t length
-) :
-	data_(std::make_unique<char[]>(length*2)),
-	capacity_(length)
-{}
-
-// Adds a character to the end of the buffer
-void isoBufferBuffer::insert ( char c ) {
-	// Add character to first half of the buffer
-	data_[top_] = c;
-	// Then to the second
-	data_[top_+capacity_] = c;
-
-	// Loop the buffer index if necessary and update size accordingly
-	top_ = (top_ + 1) % capacity_;
-	size_ = std::min(size_ + 1, capacity_);
+isoBufferBuffer::isoBufferBuffer(uint32_t length)
+	: m_data(std::make_unique<char[]>(length*2))
+	, m_capacity(length)
+{
 }
 
-void isoBufferBuffer::insert ( char const * s ) {
-	while ( *s )
+// Adds a character to the end of the buffer
+void isoBufferBuffer::insert(char c)
+{
+	// Add character to first half of the buffer
+	m_data[m_top] = c;
+	// Then to the second
+	m_data[m_top+m_capacity] = c;
+
+	// Loop the buffer index if necessary and update size accordingly
+	m_top = (m_top + 1) % m_capacity;
+	m_size = std::min(m_size + 1, m_capacity);
+}
+
+void isoBufferBuffer::insert(char const * s)
+{
+	while (*s != '\0')
 		insert(*s++);
 }
 
-void isoBufferBuffer::insert ( std::string const & s ) {
-	insert(s.c_str());
+void isoBufferBuffer::insert(std::string const & s)
+{
+	for (char c : s)
+		insert(c);
 }
 
-char const* isoBufferBuffer::query ( uint32_t count ) const {
-	if ( count > capacity_ )
+char const* isoBufferBuffer::query(uint32_t count) const
+{
+	if (count > m_capacity)
 		qFatal("isoBufferBuffer::query : you may not request more items than the capacity of the buffer");
 
-	if ( count > size_ )
+	if (count > m_size)
 		qFatal("isoBufferBuffer::query : you may not request more items than inserted");
 
-	// we offset the returned pointer to point into the second half of the buffer
-	auto offset = capacity_;
-	char const * ptr = data_.get() + top_ - count + offset;
-	return ptr;
+	return end() - count;
 }
 
-void isoBufferBuffer::clear () {
-	top_ = 0;
-	size_ = 0;
-};
-
-char const * isoBufferBuffer::begin () const {
-	return data_.get() + top_ - size_ + capacity_;
+void isoBufferBuffer::clear()
+{
+	m_top = 0;
+	m_size = 0;
 }
 
-char const * isoBufferBuffer::end () const {
-	return data_.get() + top_ + capacity_;
+char const * isoBufferBuffer::begin() const
+{
+	return m_data.get() + m_top - m_size + m_capacity;
 }
 
-uint32_t isoBufferBuffer::size () const {
-	return size_;
+char const * isoBufferBuffer::end() const
+{
+	return m_data.get() + m_top + m_capacity;
 }
 
-uint32_t isoBufferBuffer::capacity () const {
-	return capacity_;
+uint32_t isoBufferBuffer::size() const
+{
+	return m_size;
+}
+
+uint32_t isoBufferBuffer::capacity() const
+{
+	return m_capacity;
 }
 
 
 // Legacy Interface Implementation
-void isoBufferBuffer::add(std::string const & newString) {
+void isoBufferBuffer::add(std::string const & newString)
+{
     insert(newString);
 }
 
 
-void isoBufferBuffer::add(char newChar) {
+void isoBufferBuffer::add(char newChar)
+{
 	insert(newChar);
 }
 
-void isoBufferBuffer::add( uint8_t newByte ) {
+void isoBufferBuffer::add(uint8_t newByte)
+{
 	char newString[5];
 	sprintf(newString, "0x%02hhx", newByte);
 	insert((char const *)newString);
 }
 
-uint32_t isoBufferBuffer::getNumCharsInBuffer() {
+uint32_t isoBufferBuffer::getNumCharsInBuffer()
+{
     return size();
 }
 
-char const * isoBufferBuffer::get(uint32_t length) {
+char const * isoBufferBuffer::get(uint32_t length)
+{
 	return query(length);
 }

--- a/Desktop_Interface/isobufferbuffer.cpp
+++ b/Desktop_Interface/isobufferbuffer.cpp
@@ -1,5 +1,29 @@
 #include "isobufferbuffer.h"
 
+/* isoBufferBuffer is implemented as two consecutive, duplicate,
+ * ring buffers. the effect of this is that we are able to hand
+ * out pointers to pieces of contiguous memory representing the
+ * last N inserted elements (for some N <= capacity()) even
+ * when we looped back to the begining of the ring buffer less
+ * than N insertions ago
+ *
+ *     There are some differences with the original implementation
+ * functionality-wise.
+ *     Where the original implementation allowed queries half as
+ * long as the length passed in, and allocated a buffer 1.5 times
+ * the length passed in, this version allows queries of length up
+ * to the length passed into the constructor and allocates a
+ * buffer 2 times the length passed in.
+ *     Overall, this means that in contrast to the original
+ * implementation which only allowed queries up to a third as
+ * long as the allocated buffer, we can now do queries as long as
+ * half of the allocated buffer, which is a notable improvement.
+ */
+
+// TODO: go through the usages of this class and adjust the
+// size of the requested buffer to accomodate the improved memory
+// efficiency of the new algorithm
+
 isoBufferBuffer::isoBufferBuffer(
 	uint32_t length
 ) :

--- a/Desktop_Interface/isobufferbuffer.h
+++ b/Desktop_Interface/isobufferbuffer.h
@@ -1,7 +1,6 @@
 #ifndef ISOBUFFERBUFFER_H
 #define ISOBUFFERBUFFER_H
 
-#include <QDebug>
 #include <cstdint>
 #include <string>
 #include <memory>

--- a/Desktop_Interface/isobufferbuffer.h
+++ b/Desktop_Interface/isobufferbuffer.h
@@ -6,22 +6,31 @@
 #include <QDebug>
 #include <stdlib.h>
 #include <string>
+#include <memory>
 
 class isoBufferBuffer
 {
 public:
-    isoBufferBuffer(uint32_t length);
-    void add(uint8_t newByte);
+    isoBufferBuffer ( uint32_t length );
+	~isoBufferBuffer () = default;
+
+	void insert ( char );
+	char const * query ( uint32_t length ) const;
+
+	uint32_t size () const;
+	uint32_t capacity () const;
+	
+	// Legacy Interface
+	void add(uint8_t newByte);
     void add(char newChar);
     void add(std::string newString);
-    char *get(uint32_t length);
+    char const *get(uint32_t length);
     uint32_t getNumCharsInBuffer();
 private:
-    uint32_t bufferLength;
-    uint32_t mid;
-    uint32_t ptr;
-    char *buffer;
-    uint32_t numCharsInBuffer = 0;
+	std::unique_ptr<char[]> data_;
+	uint32_t capacity_;
+	uint32_t size_ = 0;
+	uint32_t top_ = 0;
 };
 
 #endif // ISOBUFFERBUFFER_H

--- a/Desktop_Interface/isobufferbuffer.h
+++ b/Desktop_Interface/isobufferbuffer.h
@@ -23,7 +23,7 @@ public:
 	// Legacy Interface
 	void add(uint8_t newByte);
     void add(char newChar);
-    void add(std::string newString);
+    void add(std::string const & newString);
     char const *get(uint32_t length);
     uint32_t getNumCharsInBuffer();
 private:

--- a/Desktop_Interface/isobufferbuffer.h
+++ b/Desktop_Interface/isobufferbuffer.h
@@ -8,9 +8,20 @@
 #include <string>
 #include <memory>
 
+// Data structure that supports the following operations:
+// insert: inserts a character at the end - O(1)
+// query: returns a pointer to the last N inserted elements - O(1)
+// add(char)    - legacy - inserts a character
+// add(uint8_t) - legacy - inserts a hex representation of a byte
+// add(string)  - legacy - inserts every character in a string
 class isoBufferBuffer
 {
 public:
+	// NOTE:
+	// While this was re-implemented to conform to more modern
+	// standars, a few decisions were made to better fit with
+	// the existing style.
+	
     isoBufferBuffer ( uint32_t length );
 	~isoBufferBuffer () = default;
 
@@ -19,7 +30,7 @@ public:
 
 	uint32_t size () const;
 	uint32_t capacity () const;
-	
+
 	// Legacy Interface
 	void add(uint8_t newByte);
     void add(char newChar);

--- a/Desktop_Interface/isobufferbuffer.h
+++ b/Desktop_Interface/isobufferbuffer.h
@@ -12,35 +12,36 @@
  *
  *  To  obtain  such  complexity,  a  double  ring buffer is used.
  *  That  is,  two  identical  ring buffers are mantained adjacent
- *  in  memory.  If we always return a pointer to the begging of a
+ *  in memory. If we always return a pointer to the beginning of a
  *  range  that ends in the second buffer, we will always return a
  *  valid  address(*),  even  when the requested length is greater
  *  than  the  current position being inserted into in the buffer.
  *
  *  (*) By  valid  address  I  mean  that  both the addresses that
- *  represent  the  begining and end of the requested query result
+ *  represent  the beginning and end of the requested query result
  *  are within the allocated buffer.
  */
-class isoBufferBuffer {
+class isoBufferBuffer
+{
 public:
-	isoBufferBuffer ( uint32_t length );
-	~isoBufferBuffer () = default;
+	isoBufferBuffer(uint32_t length);
+	~isoBufferBuffer() = default;
 
-	void insert ( char c );
-	void insert ( char const * s );
-	void insert ( std::string const & s );
+	void insert(char c);
+	void insert(char const * s);
+	void insert(std::string const & s);
 
-	char const * query ( uint32_t length ) const;
+	char const * query(uint32_t length) const;
 	// TODO?: add ability to get a copy of the content
 	// (e.g. return std::string or Qstring)
 
-	void clear ();
+	void clear();
 
-	char const * begin () const;
-	char const * end () const;
+	char const * begin() const;
+	char const * end() const;
 
-	uint32_t size () const;
-	uint32_t capacity () const;
+	uint32_t size() const;
+	uint32_t capacity() const;
 
 	// Legacy Interface
 	void add(uint8_t newByte);
@@ -49,10 +50,10 @@ public:
 	char const *get(uint32_t length);
 	uint32_t getNumCharsInBuffer();
 private:
-	std::unique_ptr<char[]> data_;
-	uint32_t capacity_;
-	uint32_t size_ = 0;
-	uint32_t top_ = 0;
+	std::unique_ptr<char[]> m_data;
+	uint32_t m_capacity;
+	uint32_t m_size = 0;
+	uint32_t m_top = 0;
 };
 
 #endif // ISOBUFFERBUFFER_H

--- a/Desktop_Interface/isobufferbuffer.h
+++ b/Desktop_Interface/isobufferbuffer.h
@@ -1,42 +1,46 @@
 #ifndef ISOBUFFERBUFFER_H
 #define ISOBUFFERBUFFER_H
 
-//isobufferbuffer is a buffer designed for getting the last n things added in reverse order, in O(1) time.
-
 #include <QDebug>
-#include <stdlib.h>
+#include <cstdint>
 #include <string>
 #include <memory>
 
-// Data structure that supports the following operations:
-// insert: inserts a character at the end - O(1)
-// query: returns a pointer to the last N inserted elements - O(1)
-// add(char)    - legacy - inserts a character
-// add(uint8_t) - legacy - inserts a hex representation of a byte
-// add(string)  - legacy - inserts every character in a string
-class isoBufferBuffer
-{
+/** @file isobufferbuffer.h
+ *  @brief This module implements a data structure that allows insertion of single characters and a view of the last N inserted characters in constant time
+ *
+ *  To obtain such complexity, a double ring buffer is used. That is, two identical ring buffers are mantained adjacent in memory.
+ *  If we always return a pointer into the second buffer, even when the requested length is greater than the current position in the buffer, we will return a valid address(*).
+ *
+ *  (*)by valid address it is meant that the address is within the allocated buffer.
+ */
+class isoBufferBuffer {
 public:
-	// NOTE:
-	// While this was re-implemented to conform to more modern
-	// standars, a few decisions were made to better fit with
-	// the existing style.
-	
-    isoBufferBuffer ( uint32_t length );
+	isoBufferBuffer ( uint32_t length );
 	~isoBufferBuffer () = default;
 
-	void insert ( char );
+	void insert ( char c );
+	void insert ( char const * s );
+	void insert ( std::string const & s );
+
 	char const * query ( uint32_t length ) const;
+	//TODO?: add ability to get a copy of the content (i.e. return std::string or Qstring)
+
+	void clear ();
+
+	char const * begin () const;
+	char const * end () const;
 
 	uint32_t size () const;
+	uint32_t capacity () const;
 	uint32_t capacity () const;
 
 	// Legacy Interface
 	void add(uint8_t newByte);
-    void add(char newChar);
-    void add(std::string const & newString);
-    char const *get(uint32_t length);
-    uint32_t getNumCharsInBuffer();
+	void add(char newChar);
+	void add(std::string const & newString);
+	char const *get(uint32_t length);
+	uint32_t getNumCharsInBuffer();
 private:
 	std::unique_ptr<char[]> data_;
 	uint32_t capacity_;

--- a/Desktop_Interface/isobufferbuffer.h
+++ b/Desktop_Interface/isobufferbuffer.h
@@ -7,12 +7,20 @@
 #include <memory>
 
 /** @file isobufferbuffer.h
- *  @brief This module implements a data structure that allows insertion of single characters and a view of the last N inserted characters in constant time
+ *  @brief This  module  implements  a  data structure that allows
+ *  insertion  of  single  characters  and  a  view  of the last N
+ *  inserted characters in constant time.
  *
- *  To obtain such complexity, a double ring buffer is used. That is, two identical ring buffers are mantained adjacent in memory.
- *  If we always return a pointer into the second buffer, even when the requested length is greater than the current position in the buffer, we will return a valid address(*).
+ *  To  obtain  such  complexity,  a  double  ring buffer is used.
+ *  That  is,  two  identical  ring buffers are mantained adjacent
+ *  in  memory.  If we always return a pointer to the begging of a
+ *  range  that ends in the second buffer, we will always return a
+ *  valid  address(*),  even  when the requested length is greater
+ *  than  the  current position being inserted into in the buffer.
  *
- *  (*)by valid address it is meant that the address is within the allocated buffer.
+ *  (*) By  valid  address  I  mean  that  both the addresses that
+ *  represent  the  begining and end of the requested query result
+ *  are within the allocated buffer.
  */
 class isoBufferBuffer {
 public:
@@ -24,7 +32,8 @@ public:
 	void insert ( std::string const & s );
 
 	char const * query ( uint32_t length ) const;
-	//TODO?: add ability to get a copy of the content (i.e. return std::string or Qstring)
+	// TODO?: add ability to get a copy of the content
+	// (e.g. return std::string or Qstring)
 
 	void clear ();
 

--- a/Desktop_Interface/isobufferbuffer.h
+++ b/Desktop_Interface/isobufferbuffer.h
@@ -33,7 +33,6 @@ public:
 
 	uint32_t size () const;
 	uint32_t capacity () const;
-	uint32_t capacity () const;
 
 	// Legacy Interface
 	void add(uint8_t newByte);


### PR DESCRIPTION
This improves the implementation and, arguably, the interface of isoBufferBuffer.

The main improvement comes from the reduction in memory allocation from a buffer 3 times as large as the maximum allowed query, to a buffer twice as large as the maximum query.

Also, the use of `char*` as a handle to the allocated buffer was replaced by `std::unique_ptr<char[]>`, removing a memory leak without the need to write a custom destructor.

The intent of this pull request is to simplify usage and make isoBufferBuffer look more like other C++ containers, including but not limited to exposing an iterator interface, and embracing const-correctness.

Examples of where this refactor would simplify usage are:

https://github.com/EspoTek/Labrador/blob/64b8b9311b14d500a4c9856f325f0e88aa9489f3/Desktop_Interface/i2cdecoder.cpp#L220-L221

Which, after this refactor, can become simply:

`console->setPlainText(QString::fromLocal8Bit(serialBuffer->begin(), serialBuffer->size())); `

And:

https://github.com/EspoTek/Labrador/blob/64b8b9311b14d500a4c9856f325f0e88aa9489f3/Desktop_Interface/i2cdecoder.cpp#L35-L36

Which can become

`serialBuffer->clear();`

If this pull request is merged, i plan on moving on to update the points where this is used to use the new interface, and later remove the old interface.

NOTE: this pull request uses C++14 features. If required, it can be modified to only use features of up to C++11.