### PR TITLE
Isobufferbuffer integration

### DIFF
--- a/Desktop_Interface/i2cdecoder.h
+++ b/Desktop_Interface/i2cdecoder.h
@@ -29,7 +29,7 @@ enum class edge: uint8_t
 
 constexpr uint8_t addressBitStreamLength = 9;
 constexpr uint8_t dataBitStreamLength = 9;
-constexpr uint32_t I2C_BUFFER_LENGTH = 8192;
+constexpr uint32_t I2C_BUFFER_LENGTH = 4096;
 
 class i2cDecoder : public QObject
 {

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -12,7 +12,6 @@
 
 #include "xmega.h"
 #include "desktop_settings.h"
-#include "isobufferbuffer.h"
 #include "genericusbdriver.h"
 
 class isoDriver;

--- a/Desktop_Interface/isobufferbuffer.cpp
+++ b/Desktop_Interface/isobufferbuffer.cpp
@@ -22,12 +22,6 @@
  * half of the allocated buffer, which is a notable improvement.
  */
 
-
-// TODO: go through the usages of this class and:
-// 1. adapt code to use the new interface and remove the old one
-// 2. adjust the size of the requested buffer to accomodate
-// the improved memory efficiency of the new algorithm
-
 isoBufferBuffer::isoBufferBuffer(uint32_t length)
 	: m_data(std::make_unique<char[]>(length*2))
 	, m_capacity(length)

--- a/Desktop_Interface/isobufferbuffer.cpp
+++ b/Desktop_Interface/isobufferbuffer.cpp
@@ -98,30 +98,11 @@ uint32_t isoBufferBuffer::capacity() const
 
 
 // Legacy Interface Implementation
-void isoBufferBuffer::add(std::string const & newString)
-{
-    insert(newString);
-}
 
-
-void isoBufferBuffer::add(char newChar)
-{
-	insert(newChar);
-}
-
-void isoBufferBuffer::add(uint8_t newByte)
+void isoBufferBuffer::insert_hex(uint8_t newByte)
 {
 	char newString[5];
 	sprintf(newString, "0x%02hhx", newByte);
 	insert((char const *)newString);
 }
 
-uint32_t isoBufferBuffer::getNumCharsInBuffer()
-{
-    return size();
-}
-
-char const * isoBufferBuffer::get(uint32_t length)
-{
-	return query(length);
-}

--- a/Desktop_Interface/isobufferbuffer.cpp
+++ b/Desktop_Interface/isobufferbuffer.cpp
@@ -59,6 +59,13 @@ void isoBufferBuffer::insert(std::string const & s)
 		insert(c);
 }
 
+void isoBufferBuffer::insert_hex(uint8_t x)
+{
+	char str[5];
+	sprintf(str, "0x%02hhx", x);
+	insert((char const *)str);
+}
+
 char const* isoBufferBuffer::query(uint32_t count) const
 {
 	if (count > m_capacity)
@@ -96,13 +103,4 @@ uint32_t isoBufferBuffer::capacity() const
 	return m_capacity;
 }
 
-
-// Legacy Interface Implementation
-
-void isoBufferBuffer::insert_hex(uint8_t newByte)
-{
-	char newString[5];
-	sprintf(newString, "0x%02hhx", newByte);
-	insert((char const *)newString);
-}
 

--- a/Desktop_Interface/isobufferbuffer.h
+++ b/Desktop_Interface/isobufferbuffer.h
@@ -44,11 +44,7 @@ public:
 	uint32_t capacity() const;
 
 	// Legacy Interface
-	void add(uint8_t newByte);
-	void add(char newChar);
-	void add(std::string const & newString);
-	char const *get(uint32_t length);
-	uint32_t getNumCharsInBuffer();
+	void insert_hex(uint8_t newByte);
 private:
 	std::unique_ptr<char[]> m_data;
 	uint32_t m_capacity;

--- a/Desktop_Interface/isobufferbuffer.h
+++ b/Desktop_Interface/isobufferbuffer.h
@@ -30,6 +30,7 @@ public:
 	void insert(char c);
 	void insert(char const * s);
 	void insert(std::string const & s);
+	void insert_hex(uint8_t x);
 
 	char const * query(uint32_t length) const;
 	// TODO?: add ability to get a copy of the content
@@ -42,9 +43,6 @@ public:
 
 	uint32_t size() const;
 	uint32_t capacity() const;
-
-	// Legacy Interface
-	void insert_hex(uint8_t newByte);
 private:
 	std::unique_ptr<char[]> m_data;
 	uint32_t m_capacity;


### PR DESCRIPTION
This pull request, when merged, will modify various files to make use of the new isoBufferBuffer interface introduced in #61. It will also remove the old interface.

In this PR, I also adjusted the length passed to the isoBufferBuffer constructor on every call site to minimize memory usage while mantaining the same maximum allowed query size from before the interface change. This means that the length passed to the constructor should now be half of what it used to be.

e.g.(this is later used to construct an isoBufferBuffer in i2cdecoder.cpp):

https://github.com/EspoTek/Labrador/blob/0e97d4c1500196d29c7318a3eb7fbb5c4ecf0ee4/Desktop_Interface/i2cdecoder.h#L32

became:

`constexpr uint32_t I2C_BUFFER_LENGTH = 4096;` 



Another change that was made was to remove the following line:

https://github.com/EspoTek/Labrador/blob/0e97d4c1500196d29c7318a3eb7fbb5c4ecf0ee4/Desktop_Interface/isobuffer.h#L15

Please let me know if this was a mistake, I am not completely sure that it was unnecessary. (grepping the code, i couldn't find where it was used on that file, and everything still builds correctly, so I figured it would be fine)