### PR TITLE
Isobuffer refactor

### DIFF
--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -203,23 +203,23 @@ void isoBuffer::glitchInsert(short type)
 void isoBuffer::enableFileIO(QFile* file, int samplesToAverage, qulonglong max_file_size)
 {
 
-	//Open the file
+	// Open the file
 	file->open(QIODevice::WriteOnly);
 	currentFile = file;
 
-	//Add the header
+	// Add the header
 	char headerLine[256];
 	sprintf(headerLine, "EspoTek Labrador DAQ V1.0 Output File\nAveraging = %d\nMode = %d\n", samplesToAverage, virtualParent->driver->deviceMode);
 	currentFile->write(headerLine);
 
-	//Set up the isoBuffer for DAQ
+	// Set up the isoBuffer for DAQ
 	fileIO_maxIncrementedSampleValue = samplesToAverage;
 	fileIO_max_file_size = max_file_size;
 	fileIO_sampleCount = 0;
 	fileIO_numBytesWritten = 0;
 	average_sample_temp = 0;
 
-	//Enable DAQ
+	// Enable DAQ
 	fileIOEnabled = true;
 
 	qDebug("File IO enabled, averaging %d samples, max file size %lluMB", samplesToAverage, max_file_size/1000000);
@@ -309,7 +309,7 @@ int capSample(isoBuffer const& self, int rbegin, int target, double seconds, dou
 	return -1;
 }
 
-//For capacitance measurement. x0, x1 and x2 are all various time points used to find the RC coefficient.
+// For capacitance measurement. x0, x1 and x2 are all various time points used to find the RC coefficient.
 int isoBuffer::cap_x0fromLast(double seconds, double vbot)
 {
 	return capSample(*this, 0, NUM_SAMPLES_SEEKING_CAP, seconds, vbot, X0_COMP_FTOR);
@@ -335,6 +335,9 @@ void isoBuffer::serialManage(double baudRate, int type, UartParity parity)
 	if (decoder == NULL)
 	{
 		decoder = new uartStyleDecoder(this);
+		// TODO: Look into using the type safe version of connect.
+		// NOTE: I believe Qt has a type-safe version of this, without the macros and the
+		// explicit signature and stuff, i think it uses member-function pointers instead.
 		connect(decoder, SIGNAL(wireDisconnected(int)), virtualParent, SLOT(serialNeedsDisabling(int)));
 	}
 	if (stopDecoding)

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -40,7 +40,8 @@ void isoBuffer::insertIntoBuffer(short item)
 	buffer[back] = item;
 	back++;
 	insertedCount++;
-	if(insertedCount > bufferEnd) {
+	if (insertedCount > bufferEnd)
+	{
 		insertedCount = bufferEnd+1;
 	}
 	if (back > bufferEnd)
@@ -171,26 +172,21 @@ short* isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit
 	free(readData);
 	readData = (short*) calloc(numSamples, sizeof(short));
 
-	// NOTE: this min seems unnecesary.
-	double pos = std::min(0, back - delaySamples - 1);
+	double itr = delaySamples + 1;
 	for (int i = 0; i < numSamples; i++)
 	{
-		while (pos < 0)
-			pos += bufferEnd;
+		while (itr > insertedCount)
+			itr -= insertedCount;
 
-		int idx = pos;
+		readData[i] = bufferAt(int(itr));
 
 		if (singleBit)
 		{
-			int subIdx = 8*(pos - floor(pos));
-			readData[i] = buffer[idx] & (1 << subIdx);
-		}
-		else
-		{
-			readData[i] = buffer[idx];
+			int subIdx = 8*(-itr-floor(-itr));
+			readData[i] &= (1 << subIdx);
 		}
 
-		pos -= timeBetweenSamples;
+		itr += timeBetweenSamples;
 	}
 
 	return readData;

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -42,7 +42,7 @@ void isoBuffer::insertIntoBuffer(short item)
 	}
 }
 
-short isoBuffer::bufferAt(int idx)
+short isoBuffer::bufferAt(int idx) const
 {
 	return buffer[back - idx];
 }
@@ -245,7 +245,7 @@ void isoBuffer::disableFileIO()
 	return;
 }
 
-double isoBuffer::sampleConvert(short sample, int TOP, bool AC)
+double isoBuffer::sampleConvert(short sample, int TOP, bool AC) const
 {
 
 	double scope_gain = (double)(virtualParent->driver->scopeGain);
@@ -263,7 +263,7 @@ double isoBuffer::sampleConvert(short sample, int TOP, bool AC)
 	return voltageLevel;
 }
 
-short isoBuffer::inverseSampleConvert(double voltageLevel, int TOP, bool AC)
+short isoBuffer::inverseSampleConvert(double voltageLevel, int TOP, bool AC) const
 {
 	double scope_gain = (double)(virtualParent->driver->scopeGain);
 	short sample;

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -148,12 +148,13 @@ short* isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit
 
 	free(readData);
 
+	readData = (short*) calloc(numSamples, sizeof(short));
+
+	// TODO: replace by return nullptr and add error handling upstream
 	if(delaySamples+1 > insertedCount)
 	{
-		return readData = nullptr;
+		return readData;
 	}
-
-	readData = (short*) calloc(numSamples, sizeof(short));
 
 	double itr = delaySamples + 1;
 	for (int i = 0; i < numSamples; i++)

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -198,11 +198,6 @@ void isoBuffer::gainBuffer(int gain_log)
 	}
 }
 
-// NOTE: glitch insert is a no-op
-void isoBuffer::glitchInsert(short type)
-{
-}
-
 void isoBuffer::enableFileIO(QFile* file, int samplesToAverage, qulonglong max_file_size)
 {
 

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -48,14 +48,14 @@ short isoBuffer::bufferAt(int idx) const
 bool isoBuffer::maybeOutputSampleToFile(double convertedSample)
 {
 	/*
-	 * This function adds a sample to an accumulator and bumps the sample count
-	 * after the sample count hits some threshold, that sample is outputted to a
-	 * file. If this 'saturates' the file, then fileIO is disabled.
+	 * This function adds a sample to an accumulator and bumps the sample count.
+	 * After the sample count hits some threshold, the accumulated sample is
+	 * outputted to a file. If this 'saturates' the file, then fileIO is disabled.
 	 */
 	average_sample_temp += convertedSample;
 	fileIO_sampleCount++;
 
-	//Check to see if we can write a new sample to file
+	// Check to see if we can write a new sample to file
 	if (fileIO_sampleCount == fileIO_maxIncrementedSampleValue)
 	{
 		char numStr[32];
@@ -68,17 +68,17 @@ bool isoBuffer::maybeOutputSampleToFile(double convertedSample)
 			currentColumn = 0;
 		}
 
-		//Reset the average and sample count for next data point
+		// Reset the average and sample count for next data point
 		fileIO_sampleCount = 0;
 		average_sample_temp = 0;
 
-		//Check to see if we've reached the max file size.
-		if (fileIO_max_file_size != 0) //value of 0 means "no limit"
+		// Check to see if we've reached the max file size.
+		if (fileIO_max_file_size != 0) // value of 0 means "no limit"
 		{
-			fileIO_numBytesWritten += 9;  //7 chars for the number, 1 for the comma and 1 for the space = 9 bytes per sample.
+			fileIO_numBytesWritten += 9;  // 7 chars for the number, 1 for the comma and 1 for the space = 9 bytes per sample.
 			if (fileIO_numBytesWritten >= fileIO_max_file_size)
 			{
-				fileIOEnabled = false; //Just in case signalling fails.
+				fileIOEnabled = false; // Just in case signalling fails.
 				fileIOinternalDisable();
 				return false;
 			}

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -39,7 +39,6 @@ void isoBuffer::insertIntoBuffer(short item)
 	if (back > bufferEnd)
 	{
 		back = 0;
-		firstTime = false;
 	}
 }
 
@@ -192,7 +191,6 @@ void isoBuffer::clearBuffer()
     }
 
     back = 0;
-    firstTime = true;
 }
 
 void isoBuffer::gainBuffer(int gain_log)

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -2,16 +2,6 @@
 #include "isodriver.h"
 #include "uartstyledecoder.h"
 
-isoBuffer::isoBuffer(QWidget* parent, int bufferLen, isoDriver* caller, unsigned char channel_value)
-	: QWidget(parent)
-{
-	buffer = (short*) calloc(bufferLen*2, sizeof(short));
-	bufferEnd = bufferLen-1;
-	samplesPerSecond = (double) bufferLen/(double)21;
-	samplesPerSecond = samplesPerSecond/375*VALID_DATA_PER_375;
-	sampleRate_bit = samplesPerSecond * 8;
-	virtualParent = caller;
-	channel = channel_value;
 namespace {
 	static char const * fileHeaderFormat =
 		"EspoTek Labrador DAQ V1.0 Output File\n"
@@ -21,27 +11,16 @@ namespace {
 	constexpr auto kSamplesSeekingCap = 20;
 	constexpr auto kTopMultimeter = 2048;
 }
-}
 
-void isoBuffer::openFile(QString newFile)
+isoBuffer::isoBuffer(QWidget* parent, int bufferLen, isoDriver* caller, unsigned char channel_value)
+	: QWidget(parent)
+	, buffer((short*)calloc(bufferLen*2, sizeof(short)))
+	, bufferEnd(bufferLen-1)
+	, samplesPerSecond(bufferLen/21.0/375*VALID_DATA_PER_375)
+	, sampleRate_bit(bufferLen/21.0/375*VALID_DATA_PER_375*8)
+	, virtualParent(caller)
+	, channel(channel_value)
 {
-	if (fptr != NULL)
-	{
-		fclose(fptr);
-	}
-	if (newFile.isEmpty())
-	{
-		fptr = NULL;
-	}
-	else
-	{
-		QByteArray temp = newFile.toLatin1();
-		char* fileName = temp.data();
-		fptr = fopen(fileName, "w");
-		if (fptr == NULL) qFatal("Null fptr in isoBuffer::openFile");
-		qDebug() << "opening file" << fileName;
-		qDebug() << "fptr = " << fptr;
-	}
 }
 
 void isoBuffer::insertIntoBuffer(short item)

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -2,10 +2,10 @@
 #include "isodriver.h"
 #include "uartstyledecoder.h"
 
-isoBuffer::isoBuffer(QWidget *parent, int bufferLen, isoDriver *caller, unsigned char channel_value)
+isoBuffer::isoBuffer(QWidget* parent, int bufferLen, isoDriver* caller, unsigned char channel_value)
 	: QWidget(parent)
 {
-	buffer = (short *) calloc(bufferLen*2, sizeof(short));
+	buffer = (short*) calloc(bufferLen*2, sizeof(short));
 	bufferEnd = bufferLen-1;
 	samplesPerSecond = (double) bufferLen/(double)21;
 	samplesPerSecond = samplesPerSecond/375*VALID_DATA_PER_375;
@@ -16,15 +16,18 @@ isoBuffer::isoBuffer(QWidget *parent, int bufferLen, isoDriver *caller, unsigned
 
 void isoBuffer::openFile(QString newFile)
 {
-	if (fptr != NULL){
+	if (fptr != NULL)
+	{
 		fclose(fptr);
 	}
-	if (newFile.isEmpty()){
+	if (newFile.isEmpty())
+	{
 		fptr = NULL;
 	}
-	else {
+	else
+	{
 		QByteArray temp = newFile.toLatin1();
-		char *fileName = temp.data();
+		char* fileName = temp.data();
 		fptr = fopen(fileName, "w");
 		if (fptr == NULL) qFatal("Null fptr in isoBuffer::openFile");
 		qDebug() << "opening file" << fileName;
@@ -58,7 +61,7 @@ bool isoBuffer::maybeOutputSampleToFile(double convertedSample)
 	fileIO_sampleCount++;
 
 	//Check to see if we can write a new sample to file
-	if(fileIO_sampleCount == fileIO_maxIncrementedSampleValue)
+	if (fileIO_sampleCount == fileIO_maxIncrementedSampleValue)
 	{
 		char numStr[32];
 		sprintf(numStr,"%7.5f, ", average_sample_temp/((double)fileIO_maxIncrementedSampleValue));
@@ -75,10 +78,10 @@ bool isoBuffer::maybeOutputSampleToFile(double convertedSample)
 		average_sample_temp = 0;
 
 		//Check to see if we've reached the max file size.
-		if(fileIO_max_file_size != 0) //value of 0 means "no limit"
+		if (fileIO_max_file_size != 0) //value of 0 means "no limit"
 		{
 			fileIO_numBytesWritten += 9;  //7 chars for the number, 1 for the comma and 1 for the space = 9 bytes per sample.
-			if(fileIO_numBytesWritten >= fileIO_max_file_size)
+			if (fileIO_numBytesWritten >= fileIO_max_file_size)
 			{
 				fileIOEnabled = false; //Just in case signalling fails.
 				fileIOinternalDisable();
@@ -91,18 +94,19 @@ bool isoBuffer::maybeOutputSampleToFile(double convertedSample)
 
 void isoBuffer::writeBuffer_char(char* data, int len)
 {
-	for (int i=0; i<len;i++){
+	for (int i=0; i<len; i++)
+	{
 		insertIntoBuffer(data[i]);
 	}
 
 	//Output to CSV
-	if(fileIOEnabled)
+	if (fileIOEnabled)
 	{
 		bool isUsingAC = channel == 1
-			? virtualParent->AC_CH1
-			: virtualParent->AC_CH2;
+		                 ? virtualParent->AC_CH1
+		                 : virtualParent->AC_CH2;
 
-		for (int i=0; i<len;i++)
+		for (int i=0; i<len; i++)
 		{
 			double convertedSample = sampleConvert(data[i], 128, isUsingAC);
 
@@ -115,29 +119,30 @@ void isoBuffer::writeBuffer_char(char* data, int len)
 
 void isoBuffer::writeBuffer_short(short* data, int len)
 {
-	for (int i=0; i<len;i++){
+	for (int i=0; i<len; i++)
+	{
 		insertIntoBuffer(data[i] >> 4);
 	}
 
 	//Output to CSV
-	if(fileIOEnabled)
+	if (fileIOEnabled)
 	{
 		bool isUsingAC = channel == 1
-			? virtualParent->AC_CH1
-			: virtualParent->AC_CH2;
+		                 ? virtualParent->AC_CH1
+		                 : virtualParent->AC_CH2;
 
-		for (int i=0; i<len;i++)
+		for (int i=0; i<len; i++)
 		{
 			double convertedSample = sampleConvert((data[i] >> 4), 2048, isUsingAC);
 
 			bool keepOutputting = maybeOutputSampleToFile(convertedSample);
 
-			if(!keepOutputting) break;
+			if (!keepOutputting) break;
 		}
 	}
 }
 
-short *isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset)
+short* isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset)
 {
 	/* Refactor Note:
 	 *
@@ -157,10 +162,10 @@ short *isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit
 	 * ~Sebastian Mestre
 	 */
 	const double timeBetweenSamples = sampleWindow * samplesPerSecond / numSamples;
-	const int delaySamples = delayOffset * samplesPerSecond;	
+	const int delaySamples = delayOffset * samplesPerSecond;
 
 	free(readData);
-	readData = (short *) calloc(numSamples, sizeof(short));
+	readData = (short*) calloc(numSamples, sizeof(short));
 
 	// NOTE: this min seems unnecesary.
 	double pos = std::min(0, back - delaySamples - 1);
@@ -189,7 +194,7 @@ short *isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit
 
 void isoBuffer::clearBuffer()
 {
-	for (int i=0; i<bufferEnd;i++)
+	for (int i=0; i<bufferEnd; i++)
 	{
 		buffer[i] = 0;
 	}
@@ -200,7 +205,8 @@ void isoBuffer::clearBuffer()
 void isoBuffer::gainBuffer(int gain_log)
 {
 	qDebug() << "Buffer shifted by" << gain_log;
-	for (int i=0; i<bufferEnd; i++){
+	for (int i=0; i<bufferEnd; i++)
+	{
 		if (gain_log == -1) buffer[i] *= 2;
 		else buffer[i] /= 2;
 	}
@@ -211,7 +217,7 @@ void isoBuffer::glitchInsert(short type)
 {
 }
 
-void isoBuffer::enableFileIO(QFile *file, int samplesToAverage, qulonglong max_file_size)
+void isoBuffer::enableFileIO(QFile* file, int samplesToAverage, qulonglong max_file_size)
 {
 
 	//Open the file
@@ -254,11 +260,12 @@ double isoBuffer::sampleConvert(short sample, int TOP, bool AC) const
 
 	voltageLevel = (sample * (vcc/2)) / (frontendGain*scope_gain*TOP);
 	if (virtualParent->driver->deviceMode != 7) voltageLevel += voltage_ref;
-	#ifdef INVERT_MM
-		if(virtualParent->driver->deviceMode == 7) voltageLevel *= -1;
-	#endif
+#ifdef INVERT_MM
+	if (virtualParent->driver->deviceMode == 7) voltageLevel *= -1;
+#endif
 
-	if(AC){
+	if (AC)
+	{
 		voltageLevel -= virtualParent->currentVmean; //This is old (1 frame in past) value and might not be good for signals with large variations in DC level (although the cap should filter that anyway)??
 	}
 	return voltageLevel;
@@ -276,7 +283,7 @@ short isoBuffer::inverseSampleConvert(double voltageLevel, int TOP, bool AC) con
 		voltageLevel += virtualParent->currentVmean;
 	}
 #ifdef INVERT_MM
-	if(virtualParent->driver->deviceMode == 7) voltageLevel *= -1;
+	if (virtualParent->driver->deviceMode == 7) voltageLevel *= -1;
 #endif
 	if (virtualParent->driver->deviceMode != 7) voltageLevel -= voltage_ref;
 
@@ -288,14 +295,14 @@ short isoBuffer::inverseSampleConvert(double voltageLevel, int TOP, bool AC) con
 #define NUM_SAMPLES_SEEKING_CAP (20)
 
 #ifdef INVERT_MM
-	constexpr auto X0_COMP_FTOR = std::greater<int>{};
-	constexpr auto X1_X2_COMP_FTOR = std::less<int>{};
+constexpr auto X0_COMP_FTOR = std::greater<int> {};
+constexpr auto X1_X2_COMP_FTOR = std::less<int> {};
 #else
-	constexpr auto X0_COMP_FTOR = std::less<int>{};
-	constexpr auto X1_X2_COMP_FTOR = std::greater<int>{};
+constexpr auto X0_COMP_FTOR = std::less<int> {};
+constexpr auto X1_X2_COMP_FTOR = std::greater<int> {};
 #endif
 
-int capSample(isoBuffer const & self, int rbegin, int target, double seconds, double value, auto comp)
+int capSample(isoBuffer const& self, int rbegin, int target, double seconds, double value, auto comp)
 {
 	int samples = seconds * self.samplesPerSecond;
 
@@ -326,7 +333,7 @@ int isoBuffer::cap_x0fromLast(double seconds, double vbot)
 }
 
 int isoBuffer::cap_x1fromLast(double seconds, int x0, double vbot)
-{	
+{
 	return capSample(*this, -x0, NUM_SAMPLES_SEEKING_CAP, seconds, vbot, X1_X2_COMP_FTOR);
 }
 
@@ -342,11 +349,13 @@ void isoBuffer::serialManage(double baudRate, int type, UartParity parity)
 	// 0 - standard UART, no parity
 	// 1 - standard UART, with parity bit
 	// 100 - I2C
-	if(decoder == NULL){
+	if (decoder == NULL)
+	{
 		decoder = new uartStyleDecoder(this);
 		connect(decoder, SIGNAL(wireDisconnected(int)), virtualParent, SLOT(serialNeedsDisabling(int)));
 	}
-	if(stopDecoding){
+	if (stopDecoding)
+	{
 		decoder->updateTimer->start(CONSOLE_UPDATE_TIMER_PERIOD);
 		stopDecoding = false;
 	}

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -206,6 +206,7 @@ void isoBuffer::gainBuffer(int gain_log)
 	}
 }
 
+// NOTE: glitch insert is a no-op
 void isoBuffer::glitchInsert(short type)
 {
 }
@@ -374,6 +375,7 @@ int isoBuffer::cap_x2fromLast(double seconds, int x1, double vtop)
 	return -1;
 }
 
+// NOTE: type appears to be unused
 void isoBuffer::serialManage(double baudRate, int type, UartParity parity)
 {
 	//Types:

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -5,31 +5,31 @@
 isoBuffer::isoBuffer(QWidget *parent, int bufferLen, isoDriver *caller, unsigned char channel_value)
 	: QWidget(parent)
 {
-    buffer = (short *) calloc(bufferLen*2, sizeof(short));
-    bufferEnd = bufferLen-1;
-    samplesPerSecond = (double) bufferLen/(double)21;
-    samplesPerSecond = samplesPerSecond/375*VALID_DATA_PER_375;
-    sampleRate_bit = samplesPerSecond * 8;
-    virtualParent = caller;
-    channel = channel_value;
+	buffer = (short *) calloc(bufferLen*2, sizeof(short));
+	bufferEnd = bufferLen-1;
+	samplesPerSecond = (double) bufferLen/(double)21;
+	samplesPerSecond = samplesPerSecond/375*VALID_DATA_PER_375;
+	sampleRate_bit = samplesPerSecond * 8;
+	virtualParent = caller;
+	channel = channel_value;
 }
 
 void isoBuffer::openFile(QString newFile)
 {
-    if (fptr != NULL){
-        fclose(fptr);
-    }
-    if (newFile.isEmpty()){
-        fptr = NULL;
-    }
-    else {
-        QByteArray temp = newFile.toLatin1();
-        char *fileName = temp.data();
-        fptr = fopen(fileName, "w");
-        if (fptr == NULL) qFatal("Null fptr in isoBuffer::openFile");
-        qDebug() << "opening file" << fileName;
-        qDebug() << "fptr = " << fptr;
-    }
+	if (fptr != NULL){
+		fclose(fptr);
+	}
+	if (newFile.isEmpty()){
+		fptr = NULL;
+	}
+	else {
+		QByteArray temp = newFile.toLatin1();
+		char *fileName = temp.data();
+		fptr = fopen(fileName, "w");
+		if (fptr == NULL) qFatal("Null fptr in isoBuffer::openFile");
+		qDebug() << "opening file" << fileName;
+		qDebug() << "fptr = " << fptr;
+	}
 }
 
 void isoBuffer::insertIntoBuffer(short item)
@@ -66,8 +66,8 @@ bool isoBuffer::maybeOutputSampleToFile(double convertedSample)
 		currentColumn++;
 		if (currentColumn >= COLUMN_BREAK)
 		{
-		    currentFile->write("\n");
-		    currentColumn = 0;
+			currentFile->write("\n");
+			currentColumn = 0;
 		}
 
 		//Reset the average and sample count for next data point
@@ -77,13 +77,13 @@ bool isoBuffer::maybeOutputSampleToFile(double convertedSample)
 		//Check to see if we've reached the max file size.
 		if(fileIO_max_file_size != 0) //value of 0 means "no limit"
 		{
-		    fileIO_numBytesWritten += 9;  //7 chars for the number, 1 for the comma and 1 for the space = 9 bytes per sample.
-		    if(fileIO_numBytesWritten >= fileIO_max_file_size)
+			fileIO_numBytesWritten += 9;  //7 chars for the number, 1 for the comma and 1 for the space = 9 bytes per sample.
+			if(fileIO_numBytesWritten >= fileIO_max_file_size)
 			{
-		        fileIOEnabled = false; //Just in case signalling fails.
-		        fileIOinternalDisable();
+				fileIOEnabled = false; //Just in case signalling fails.
+				fileIOinternalDisable();
 				return false;
-		    }
+			}
 		}
 	}
 	return true;
@@ -95,7 +95,7 @@ void isoBuffer::writeBuffer_char(char* data, int len)
 		insertIntoBuffer(data[i]);
 	}
 
-    //Output to CSV
+	//Output to CSV
 	if(fileIOEnabled)
 	{
 		bool isUsingAC = channel == 1
@@ -104,7 +104,7 @@ void isoBuffer::writeBuffer_char(char* data, int len)
 
 		for (int i=0; i<len;i++)
 		{
-		    double convertedSample = sampleConvert(data[i], 128, isUsingAC);
+			double convertedSample = sampleConvert(data[i], 128, isUsingAC);
 
 			bool keepOutputting = maybeOutputSampleToFile(convertedSample);
 
@@ -115,11 +115,11 @@ void isoBuffer::writeBuffer_char(char* data, int len)
 
 void isoBuffer::writeBuffer_short(short* data, int len)
 {
-    for (int i=0; i<len;i++){
+	for (int i=0; i<len;i++){
 		insertIntoBuffer(data[i] >> 4);
 	}
 
-    //Output to CSV
+	//Output to CSV
 	if(fileIOEnabled)
 	{
 		bool isUsingAC = channel == 1
@@ -134,7 +134,7 @@ void isoBuffer::writeBuffer_short(short* data, int len)
 
 			if(!keepOutputting) break;
 		}
-    }
+	}
 }
 
 short *isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset)
@@ -182,28 +182,28 @@ short *isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit
 		}
 
 		pos -= timeBetweenSamples;
-    }
+	}
 
-    return readData;
+	return readData;
 }
 
 void isoBuffer::clearBuffer()
 {
-    for (int i=0; i<bufferEnd;i++)
+	for (int i=0; i<bufferEnd;i++)
 	{
-        buffer[i] = 0;
-    }
+		buffer[i] = 0;
+	}
 
-    back = 0;
+	back = 0;
 }
 
 void isoBuffer::gainBuffer(int gain_log)
 {
-    qDebug() << "Buffer shifted by" << gain_log;
-    for (int i=0; i<bufferEnd; i++){
-        if (gain_log == -1) buffer[i] *= 2;
-        else buffer[i] /= 2;
-    }
+	qDebug() << "Buffer shifted by" << gain_log;
+	for (int i=0; i<bufferEnd; i++){
+		if (gain_log == -1) buffer[i] *= 2;
+		else buffer[i] /= 2;
+	}
 }
 
 void isoBuffer::glitchInsert(short type)
@@ -213,85 +213,85 @@ void isoBuffer::glitchInsert(short type)
 void isoBuffer::enableFileIO(QFile *file, int samplesToAverage, qulonglong max_file_size)
 {
 
-    //Open the file
-    file->open(QIODevice::WriteOnly);
-    currentFile = file;
+	//Open the file
+	file->open(QIODevice::WriteOnly);
+	currentFile = file;
 
-    //Add the header
-    char headerLine[256];
-    sprintf(headerLine, "EspoTek Labrador DAQ V1.0 Output File\nAveraging = %d\nMode = %d\n", samplesToAverage, virtualParent->driver->deviceMode);
-    currentFile->write(headerLine);
+	//Add the header
+	char headerLine[256];
+	sprintf(headerLine, "EspoTek Labrador DAQ V1.0 Output File\nAveraging = %d\nMode = %d\n", samplesToAverage, virtualParent->driver->deviceMode);
+	currentFile->write(headerLine);
 
-    //Set up the isoBuffer for DAQ
-    fileIO_maxIncrementedSampleValue = samplesToAverage;
-    fileIO_max_file_size = max_file_size;
-    fileIO_sampleCount = 0;
-    fileIO_numBytesWritten = 0;
-    average_sample_temp = 0;
+	//Set up the isoBuffer for DAQ
+	fileIO_maxIncrementedSampleValue = samplesToAverage;
+	fileIO_max_file_size = max_file_size;
+	fileIO_sampleCount = 0;
+	fileIO_numBytesWritten = 0;
+	average_sample_temp = 0;
 
-    //Enable DAQ
-    fileIOEnabled = true;
+	//Enable DAQ
+	fileIOEnabled = true;
 
-    qDebug("File IO enabled, averaging %d samples, max file size %lluMB", samplesToAverage, max_file_size/1000000);
-    qDebug() << max_file_size;
-    return;
+	qDebug("File IO enabled, averaging %d samples, max file size %lluMB", samplesToAverage, max_file_size/1000000);
+	qDebug() << max_file_size;
+	return;
 }
 
 void isoBuffer::disableFileIO()
 {
-    fileIOEnabled = false;
-    currentColumn = 0;
-    currentFile->close();
-    return;
+	fileIOEnabled = false;
+	currentColumn = 0;
+	currentFile->close();
+	return;
 }
 
 double isoBuffer::sampleConvert(short sample, int TOP, bool AC)
 {
 
-    double scope_gain = (double)(virtualParent->driver->scopeGain);
-    double voltageLevel;
+	double scope_gain = (double)(virtualParent->driver->scopeGain);
+	double voltageLevel;
 
-    voltageLevel = (sample * (vcc/2)) / (frontendGain*scope_gain*TOP);
-    if (virtualParent->driver->deviceMode != 7) voltageLevel += voltage_ref;
-    #ifdef INVERT_MM
-        if(virtualParent->driver->deviceMode == 7) voltageLevel *= -1;
-    #endif
+	voltageLevel = (sample * (vcc/2)) / (frontendGain*scope_gain*TOP);
+	if (virtualParent->driver->deviceMode != 7) voltageLevel += voltage_ref;
+	#ifdef INVERT_MM
+		if(virtualParent->driver->deviceMode == 7) voltageLevel *= -1;
+	#endif
 
-    if(AC){
-        voltageLevel -= virtualParent->currentVmean; //This is old (1 frame in past) value and might not be good for signals with large variations in DC level (although the cap should filter that anyway)??
-    }
-    return voltageLevel;
+	if(AC){
+		voltageLevel -= virtualParent->currentVmean; //This is old (1 frame in past) value and might not be good for signals with large variations in DC level (although the cap should filter that anyway)??
+	}
+	return voltageLevel;
 }
 
 short isoBuffer::inverseSampleConvert(double voltageLevel, int TOP, bool AC)
 {
-    double scope_gain = (double)(virtualParent->driver->scopeGain);
-    short sample;
+	double scope_gain = (double)(virtualParent->driver->scopeGain);
+	short sample;
 
-    if (AC)
+	if (AC)
 	{
 		// This is old (1 frame in past) value and might not be good for signals with
 		// large variations in DC level (although the cap should filter that anyway)??
-        voltageLevel += virtualParent->currentVmean;
-    }
+		voltageLevel += virtualParent->currentVmean;
+	}
 #ifdef INVERT_MM
-    if(virtualParent->driver->deviceMode == 7) voltageLevel *= -1;
+	if(virtualParent->driver->deviceMode == 7) voltageLevel *= -1;
 #endif
-    if (virtualParent->driver->deviceMode != 7) voltageLevel -= voltage_ref;
+	if (virtualParent->driver->deviceMode != 7) voltageLevel -= voltage_ref;
 
-    //voltageLevel = (sample * (vcc/2)) / (frontendGain*scope_gain*TOP);
-    sample = (voltageLevel * (frontendGain*scope_gain*TOP))/(vcc/2);
-    return sample;
+	//voltageLevel = (sample * (vcc/2)) / (frontendGain*scope_gain*TOP);
+	sample = (voltageLevel * (frontendGain*scope_gain*TOP))/(vcc/2);
+	return sample;
 }
 
 #define NUM_SAMPLES_SEEKING_CAP (20)
 
 #ifdef INVERT_MM
-    #define X0_COMPARISON_CAP >
-    #define X1_X2_COMPARISON_CAP <
+	#define X0_COMPARISON_CAP >
+	#define X1_X2_COMPARISON_CAP <
 #else
-    #define X0_COMPARISON_CAP <
-    #define X1_X2_COMPARISON_CAP >
+	#define X0_COMPARISON_CAP <
+	#define X1_X2_COMPARISON_CAP >
 #endif
 
 //For capacitance measurement. x0, x1 and x2 are all various time points used to find the RC coefficient.
@@ -323,72 +323,72 @@ int isoBuffer::cap_x0fromLast(double seconds, double vbot)
 
 int isoBuffer::cap_x1fromLast(double seconds, int x0, double vbot)
 {
-    int samplesInPast = seconds * samplesPerSecond;
-    samplesInPast -= x0;
-    if(back < samplesInPast){
-        return -1; //too hard, not really important
-    }
-    short vbot_s = inverseSampleConvert(vbot, 2048, 0);
-    qDebug() << "vbot_s (x1) = " << vbot_s;
+	int samplesInPast = seconds * samplesPerSecond;
+	samplesInPast -= x0;
+	if(back < samplesInPast){
+		return -1; //too hard, not really important
+	}
+	short vbot_s = inverseSampleConvert(vbot, 2048, 0);
+	qDebug() << "vbot_s (x1) = " << vbot_s;
 
-    int num_found = 0;
-    for(int i=samplesInPast; i; i--){
-        short currentSample = bufferAt(i);
-        if(currentSample X1_X2_COMPARISON_CAP vbot_s){
-            num_found++;
-        } else num_found--;
-        if(num_found < 0){
-            num_found = 0;
-        }
-        if (num_found > NUM_SAMPLES_SEEKING_CAP){
-            return samplesInPast-i + x0;
-        }
+	int num_found = 0;
+	for(int i=samplesInPast; i; i--){
+		short currentSample = bufferAt(i);
+		if(currentSample X1_X2_COMPARISON_CAP vbot_s){
+			num_found++;
+		} else num_found--;
+		if(num_found < 0){
+			num_found = 0;
+		}
+		if (num_found > NUM_SAMPLES_SEEKING_CAP){
+			return samplesInPast-i + x0;
+		}
 
-    }
-    return -1;
+	}
+	return -1;
 }
 
 int isoBuffer::cap_x2fromLast(double seconds, int x1, double vtop)
 {
-    int samplesInPast = seconds * samplesPerSecond;
-    samplesInPast -= x1;
-    if(back < samplesInPast){
-        return -1; //too hard, not really important
-    }
-    short vtop_s = inverseSampleConvert(vtop, 2048, 0);
-    qDebug() << "vtop_s (x2) = " << vtop_s;
+	int samplesInPast = seconds * samplesPerSecond;
+	samplesInPast -= x1;
+	if(back < samplesInPast){
+		return -1; //too hard, not really important
+	}
+	short vtop_s = inverseSampleConvert(vtop, 2048, 0);
+	qDebug() << "vtop_s (x2) = " << vtop_s;
 
-    int num_found = 0;
-    for(int i=samplesInPast; i; i--){
-        short currentSample = bufferAt(i);
-        if(currentSample X1_X2_COMPARISON_CAP vtop_s){
-            num_found++;
-        } else num_found--;
-        if(num_found < 0){
-            num_found = 0;
-        }
-        if (num_found > NUM_SAMPLES_SEEKING_CAP){
-            return samplesInPast-i + x1;
-        }
-    }
-    return -1;
+	int num_found = 0;
+	for(int i=samplesInPast; i; i--){
+		short currentSample = bufferAt(i);
+		if(currentSample X1_X2_COMPARISON_CAP vtop_s){
+			num_found++;
+		} else num_found--;
+		if(num_found < 0){
+			num_found = 0;
+		}
+		if (num_found > NUM_SAMPLES_SEEKING_CAP){
+			return samplesInPast-i + x1;
+		}
+	}
+	return -1;
 }
 
 void isoBuffer::serialManage(double baudRate, int type, UartParity parity)
 {
-    //Types:
-    // 0 - standard UART, no parity
-    // 1 - standard UART, with parity bit
-    // 100 - I2C
-    if(decoder == NULL){
-        decoder = new uartStyleDecoder(this);
-        connect(decoder, SIGNAL(wireDisconnected(int)), virtualParent, SLOT(serialNeedsDisabling(int)));
-    }
-    if(stopDecoding){
-        decoder->updateTimer->start(CONSOLE_UPDATE_TIMER_PERIOD);
-        stopDecoding = false;
-    }
-    decoder->setParityMode(parity);
-    decoder->serialDecode(baudRate);
+	//Types:
+	// 0 - standard UART, no parity
+	// 1 - standard UART, with parity bit
+	// 100 - I2C
+	if(decoder == NULL){
+		decoder = new uartStyleDecoder(this);
+		connect(decoder, SIGNAL(wireDisconnected(int)), virtualParent, SLOT(serialNeedsDisabling(int)));
+	}
+	if(stopDecoding){
+		decoder->updateTimer->start(CONSOLE_UPDATE_TIMER_PERIOD);
+		stopDecoding = false;
+	}
+	decoder->setParityMode(parity);
+	decoder->serialDecode(baudRate);
 }
 

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -9,6 +9,15 @@ namespace {
 		"Mode = %d\n";
 
 	constexpr auto kSamplesSeekingCap = 20;
+
+	#ifdef INVERT_MM
+	constexpr auto fX0Comp = std::greater<int> {};
+	constexpr auto fX1X2Comp = std::less<int> {};
+	#else
+	constexpr auto fX0Comp = std::less<int> {};
+	constexpr auto fX1X2Comp = std::greater<int> {};
+	#endif
+
 	constexpr auto kTopMultimeter = 2048;
 }
 
@@ -273,14 +282,6 @@ short isoBuffer::inverseSampleConvert(double voltageLevel, int TOP, bool AC) con
 	return sample;
 }
 
-#ifdef INVERT_MM
-constexpr auto X0_COMP_FTOR = std::greater<int> {};
-constexpr auto X1_X2_COMP_FTOR = std::less<int> {};
-#else
-constexpr auto X0_COMP_FTOR = std::less<int> {};
-constexpr auto X1_X2_COMP_FTOR = std::greater<int> {};
-#endif
-
 template<typename Function>
 int isoBuffer::capSample(int offset, int target, double seconds, double value, Function comp)
 {
@@ -309,17 +310,17 @@ int isoBuffer::capSample(int offset, int target, double seconds, double value, F
 // For capacitance measurement. x0, x1 and x2 are all various time points used to find the RC coefficient.
 int isoBuffer::cap_x0fromLast(double seconds, double vbot)
 {
-	return capSample(0, kSamplesSeekingCap, seconds, vbot, X0_COMP_FTOR);
+	return capSample(0, kSamplesSeekingCap, seconds, vbot, fX0Comp);
 }
 
 int isoBuffer::cap_x1fromLast(double seconds, int x0, double vbot)
 {
-	return capSample(-x0, kSamplesSeekingCap, seconds, vbot, X1_X2_COMP_FTOR);
+	return capSample(-x0, kSamplesSeekingCap, seconds, vbot, fX1X2Comp);
 }
 
 int isoBuffer::cap_x2fromLast(double seconds, int x1, double vtop)
 {
-	return capSample(-x1, kSamplesSeekingCap, seconds, vtop, X1_X2_COMP_FTOR);
+	return capSample(-x1, kSamplesSeekingCap, seconds, vtop, fX1X2Comp);
 }
 
 void isoBuffer::serialManage(double baudRate, UartParity parity)

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -32,6 +32,55 @@ void isoBuffer::openFile(QString newFile)
     }
 }
 
+void isoBuffer::insertIntoBuffer(short item)
+{
+	buffer[back] = item;
+	back++;
+	if (back > bufferEnd)
+	{
+		back = 0;
+		firstTime = false;
+	}
+}
+
+short isoBuffer::bufferAt(int idx)
+{
+	return buffer[back - idx];
+}
+
+bool isoBuffer::maybeOutputSampleToFile(double convertedSample)
+{
+	average_sample_temp += convertedSample;
+	fileIO_sampleCount++;
+
+	//Check to see if we can write a new sample to file
+	if(fileIO_sampleCount == fileIO_maxIncrementedSampleValue){
+		char numStr[32];
+		sprintf(numStr,"%7.5f, ", average_sample_temp/((double)fileIO_maxIncrementedSampleValue));
+		currentFile->write(numStr);
+		currentColumn++;
+		if (currentColumn >= COLUMN_BREAK){
+		    currentFile->write("\n");
+		    currentColumn = 0;
+		}
+
+		//Reset the average and sample count for next data point
+		fileIO_sampleCount = 0;
+		average_sample_temp = 0;
+
+		//Check to see if we've reached the max file size.
+		if(fileIO_max_file_size != 0){ //value of 0 means "no limit"
+		    fileIO_numBytesWritten += 9;  //7 chars for the number, 1 for the comma and 1 for the space = 9 bytes per sample.
+		    if(fileIO_numBytesWritten >= fileIO_max_file_size){
+		        fileIOEnabled = false; //Just in case signalling fails.
+		        fileIOinternalDisable();
+				return false;
+		    }
+		}
+	}
+	return true;
+}
+
 void isoBuffer::writeBuffer_char(char* data, int len)
 {
     double convertedSample;

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -12,6 +12,15 @@ isoBuffer::isoBuffer(QWidget* parent, int bufferLen, isoDriver* caller, unsigned
 	sampleRate_bit = samplesPerSecond * 8;
 	virtualParent = caller;
 	channel = channel_value;
+namespace {
+	static char const * fileHeaderFormat =
+		"EspoTek Labrador DAQ V1.0 Output File\n"
+		"Averaging = %d\n"
+		"Mode = %d\n";
+
+	constexpr auto kSamplesSeekingCap = 20;
+	constexpr auto kTopMultimeter = 2048;
+}
 }
 
 void isoBuffer::openFile(QString newFile)

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -39,6 +39,10 @@ void isoBuffer::insertIntoBuffer(short item)
 {
 	buffer[back] = item;
 	back++;
+	insertedCount++;
+	if(insertedCount > bufferEnd) {
+		insertedCount = bufferEnd+1;
+	}
 	if (back > bufferEnd)
 	{
 		back = 0;

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -177,7 +177,7 @@ short* isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit
 
 void isoBuffer::clearBuffer()
 {
-	for (int i=0; i<bufferEnd; i++)
+	for (int i = 0; i < bufferEnd; i++)
 	{
 		buffer[i] = 0;
 	}
@@ -237,11 +237,9 @@ void isoBuffer::disableFileIO()
 
 double isoBuffer::sampleConvert(short sample, int TOP, bool AC) const
 {
-
 	double scope_gain = (double)(virtualParent->driver->scopeGain);
-	double voltageLevel;
 
-	voltageLevel = (sample * (vcc/2)) / (frontendGain*scope_gain*TOP);
+	double voltageLevel = (sample * (vcc/2)) / (frontendGain*scope_gain*TOP);
 	if (virtualParent->driver->deviceMode != 7) voltageLevel += voltage_ref;
 #ifdef INVERT_MM
 	if (virtualParent->driver->deviceMode == 7) voltageLevel *= -1;
@@ -249,15 +247,16 @@ double isoBuffer::sampleConvert(short sample, int TOP, bool AC) const
 
 	if (AC)
 	{
-		voltageLevel -= virtualParent->currentVmean; //This is old (1 frame in past) value and might not be good for signals with large variations in DC level (although the cap should filter that anyway)??
+		// This is old (1 frame in past) value and might not be good for signals with
+		// large variations in DC level (although the cap should filter that anyway)??
+		voltageLevel -= virtualParent->currentVmean;
 	}
 	return voltageLevel;
 }
 
 short isoBuffer::inverseSampleConvert(double voltageLevel, int TOP, bool AC) const
 {
-	double scope_gain = (double)(virtualParent->driver->scopeGain);
-	short sample;
+	double scope_gain = virtualParent->driver->scopeGain;
 
 	if (AC)
 	{
@@ -265,13 +264,14 @@ short isoBuffer::inverseSampleConvert(double voltageLevel, int TOP, bool AC) con
 		// large variations in DC level (although the cap should filter that anyway)??
 		voltageLevel += virtualParent->currentVmean;
 	}
+
 #ifdef INVERT_MM
 	if (virtualParent->driver->deviceMode == 7) voltageLevel *= -1;
 #endif
 	if (virtualParent->driver->deviceMode != 7) voltageLevel -= voltage_ref;
 
-	//voltageLevel = (sample * (vcc/2)) / (frontendGain*scope_gain*TOP);
-	sample = (voltageLevel * (frontendGain*scope_gain*TOP))/(vcc/2);
+	// voltageLevel = (sample * (vcc/2)) / (frontendGain*scope_gain*TOP);
+	short sample = (voltageLevel * (frontendGain*scope_gain*TOP))/(vcc/2);
 	return sample;
 }
 

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -211,7 +211,7 @@ void isoBuffer::enableFileIO(QFile* file, int samplesToAverage, qulonglong max_f
 
 	// Add the header
 	char headerLine[256];
-	sprintf(headerLine, "EspoTek Labrador DAQ V1.0 Output File\nAveraging = %d\nMode = %d\n", samplesToAverage, virtualParent->driver->deviceMode);
+	sprintf(headerLine, fileHeaderFormat, samplesToAverage, virtualParent->driver->deviceMode);
 	currentFile->write(headerLine);
 
 	// Set up the isoBuffer for DAQ

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -28,10 +28,12 @@ void isoBuffer::insertIntoBuffer(short item)
 	buffer[back] = item;
 	back++;
 	insertedCount++;
+
 	if (insertedCount > bufferEnd)
 	{
 		insertedCount = bufferEnd+1;
 	}
+
 	if (back > bufferEnd)
 	{
 		back = 0;

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -188,10 +188,12 @@ void isoBuffer::clearBuffer()
 void isoBuffer::gainBuffer(int gain_log)
 {
 	qDebug() << "Buffer shifted by" << gain_log;
-	for (int i=0; i<bufferEnd; i++)
+	for (int i = 0; i < bufferEnd; i++)
 	{
-		if (gain_log == -1) buffer[i] *= 2;
-		else buffer[i] /= 2;
+		if (gain_log < 0)
+			buffer[i] <<= -gain_log;
+		else
+			buffer[i] >>= gain_log;
 	}
 }
 

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -161,8 +161,9 @@ short* isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit
 	 *    - UNIX 7
 	 *   I do not know of any non-compliant somewhat modern implementations.
 	 *
-	 * The expected behavior is to cycle backwards over the buffer with a stride of
-	 * timeBetweenSamples steps, and insert the touched elements into readBuffer.
+	 * The expected behavior is to cycle backwards over the buffer, taking into
+	 * acount only the part of the buffer that has things stored, with a stride
+	 * of timeBetweenSamples steps, and insert the touched elements into readData.
 	 *
 	 * ~Sebastian Mestre
 	 */

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -116,19 +116,18 @@ void isoBuffer::writeBuffer_char(char* data, int len)
 void isoBuffer::writeBuffer_short(short* data, int len)
 {
     for (int i=0; i<len;i++){
-        //qDebug() << "i = " << i;
 		insertIntoBuffer(data[i] >> 4);
 	}
 
     //Output to CSV
 	if(fileIOEnabled)
 	{
+		bool isUsingAC = channel == 1
+			? virtualParent->AC_CH1
+			: virtualParent->AC_CH2;
+
 		for (int i=0; i<len;i++)
 		{
-			bool isUsingAC = channel == 1
-				? virtualParent->AC_CH1
-				: virtualParent->AC_CH2;
-
 			double convertedSample = sampleConvert((data[i] >> 4), 2048, isUsingAC);
 
 			bool keepOutputting = maybeOutputSampleToFile(convertedSample);

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -147,6 +147,12 @@ short* isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit
 	const int delaySamples = delayOffset * samplesPerSecond;
 
 	free(readData);
+
+	if(delaySamples+1 > insertedCount)
+	{
+		return readData = nullptr;
+	}
+
 	readData = (short*) calloc(numSamples, sizeof(short));
 
 	double itr = delaySamples + 1;

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -326,13 +326,8 @@ int isoBuffer::cap_x2fromLast(double seconds, int x1, double vtop)
 	return capSample(-x1, kSamplesSeekingCap, seconds, vtop, X1_X2_COMP_FTOR);
 }
 
-// NOTE: type appears to be unused
-void isoBuffer::serialManage(double baudRate, int type, UartParity parity)
+void isoBuffer::serialManage(double baudRate, UartParity parity)
 {
-	//Types:
-	// 0 - standard UART, no parity
-	// 1 - standard UART, with parity bit
-	// 100 - I2C
 	if (decoder == NULL)
 	{
 		decoder = new uartStyleDecoder(this);

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -49,16 +49,23 @@ short isoBuffer::bufferAt(int idx)
 
 bool isoBuffer::maybeOutputSampleToFile(double convertedSample)
 {
+	/*
+	 * This function adds a sample to an accumulator and bumps the sample count
+	 * after the sample count hits some threshold, that sample is outputted to a
+	 * file. If this 'saturates' the file, then fileIO is disabled.
+	 */
 	average_sample_temp += convertedSample;
 	fileIO_sampleCount++;
 
 	//Check to see if we can write a new sample to file
-	if(fileIO_sampleCount == fileIO_maxIncrementedSampleValue){
+	if(fileIO_sampleCount == fileIO_maxIncrementedSampleValue)
+	{
 		char numStr[32];
 		sprintf(numStr,"%7.5f, ", average_sample_temp/((double)fileIO_maxIncrementedSampleValue));
 		currentFile->write(numStr);
 		currentColumn++;
-		if (currentColumn >= COLUMN_BREAK){
+		if (currentColumn >= COLUMN_BREAK)
+		{
 		    currentFile->write("\n");
 		    currentColumn = 0;
 		}
@@ -68,9 +75,11 @@ bool isoBuffer::maybeOutputSampleToFile(double convertedSample)
 		average_sample_temp = 0;
 
 		//Check to see if we've reached the max file size.
-		if(fileIO_max_file_size != 0){ //value of 0 means "no limit"
+		if(fileIO_max_file_size != 0) //value of 0 means "no limit"
+		{
 		    fileIO_numBytesWritten += 9;  //7 chars for the number, 1 for the comma and 1 for the space = 9 bytes per sample.
-		    if(fileIO_numBytesWritten >= fileIO_max_file_size){
+		    if(fileIO_numBytesWritten >= fileIO_max_file_size)
+			{
 		        fileIOEnabled = false; //Just in case signalling fails.
 		        fileIOinternalDisable();
 				return false;

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -34,9 +34,6 @@ public:
 	isoBuffer(QWidget* parent = 0, int bufferLen = 0, isoDriver* caller = 0, unsigned char channel_value = 0);
 	// TODO?: Add a destructor
 
-	//Generic Functions
-	void openFile(QString newFile);
-
 //	Basic buffer operations
 	short bufferAt(int idx) const;
 	void insertIntoBuffer(short item);
@@ -45,6 +42,10 @@ public:
 	void glitchInsert(short type); // NO-OP
 
 // Advanced buffer operations
+private:
+	template<typename T, typename Function>
+	void writeBuffer(T* data, int len, int TOP, Function transform);
+public:
 	void writeBuffer_char(char* data, int len);
 	void writeBuffer_short(short* data, int len);
 

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -29,7 +29,7 @@ enum class UartParity : uint8_t;
 // TODO: Make private what should be private
 class isoBuffer : public QWidget
 {
-    Q_OBJECT
+	Q_OBJECT
 public:
 	isoBuffer(QWidget *parent = 0, int bufferLen = 0, isoDriver *caller = 0, unsigned char channel_value = 0);
 	// TODO?: Add a destructor

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -77,6 +77,7 @@ public:
 
 //	Internal Storage
 	int back = 0;
+	int insertedCount = 0;
 	int bufferEnd;
 	short* buffer;
 	short* readData = NULL;

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -31,7 +31,7 @@ class isoBuffer : public QWidget
 {
 	Q_OBJECT
 public:
-	isoBuffer(QWidget *parent = 0, int bufferLen = 0, isoDriver *caller = 0, unsigned char channel_value = 0);
+	isoBuffer(QWidget* parent = 0, int bufferLen = 0, isoDriver* caller = 0, unsigned char channel_value = 0);
 	// TODO?: Add a destructor
 
 	//Generic Functions
@@ -43,13 +43,13 @@ public:
 	void clearBuffer();
 	void gainBuffer(int gain_log);
 	void glitchInsert(short type); // NO-OP
-	
-// Advanced buffer operations
-	void writeBuffer_char(char *data, int len);
-	void writeBuffer_short(short *data, int len);
 
-	short *readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset);
-	
+// Advanced buffer operations
+	void writeBuffer_char(char* data, int len);
+	void writeBuffer_short(short* data, int len);
+
+	short* readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset);
+
 //	file I/O
 	bool maybeOutputSampleToFile(double convertedSample);
 	double sampleConvert(short sample, int TOP, bool AC) const;
@@ -64,7 +64,8 @@ public:
 
 //	Presentantion?
 // NOTE: it seems like these are never initialized but they are used as though they were...
-	QPlainTextEdit *console1, *console2;
+	QPlainTextEdit* console1;
+	QPlainTextEdit* console2;
 	unsigned char channel = 255;
 	bool serialAutoScroll = true;
 
@@ -77,29 +78,29 @@ public:
 //	Internal Storage
 	int back = 0;
 	int bufferEnd;
-	short *buffer;
-	short *readData = NULL;
+	short* buffer;
+	short* readData = NULL;
 
 //	UARTS decoding
-	uartStyleDecoder *decoder = NULL;
+	uartStyleDecoder* decoder = NULL;
 	// TODO: change this to keepDecoding
 	bool stopDecoding = false;
 private:
 //	File I/O
 	bool fileIOEnabled = false;
 	FILE* fptr = NULL;
-	QFile *currentFile;
+	QFile* currentFile;
 	int fileIO_maxIncrementedSampleValue;
 	int fileIO_sampleCount;
 	qulonglong fileIO_max_file_size;
 	qulonglong fileIO_numBytesWritten;
 	unsigned int currentColumn = 0;
-	isoDriver *virtualParent;
+	isoDriver* virtualParent;
 	double average_sample_temp;
 signals:
 	void fileIOinternalDisable();
 public slots:
-	void enableFileIO(QFile *file, int samplesToAverage, qulonglong max_file_size);
+	void enableFileIO(QFile* file, int samplesToAverage, qulonglong max_file_size);
 	void disableFileIO();
 };
 

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -56,6 +56,10 @@ public:
 	double sampleConvert(short sample, int TOP, bool AC) const;
 	short inverseSampleConvert(double voltageLevel, int TOP, bool AC) const;
 
+private:
+	template<typename Function>
+	int capSample(int offset, int target, double seconds, double value, Function comp);
+public:
 	int cap_x0fromLast(double seconds, double vbot);
 	int cap_x1fromLast(double seconds, int x0, double vbot);
 	int cap_x2fromLast(double seconds, int x1, double vtop);

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -84,11 +84,6 @@ public:
 	// TODO: change this to keepDecoding
     bool stopDecoding = false;
 private:
-    
-//	Represents wether or not we have already gone around the buffer
-	// NOTE: Appears to be unused: maybe it should be removed?
-	bool firstTime = true;
-
 //	File I/O
     bool fileIOEnabled = false;
     FILE* fptr = NULL;

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -1,6 +1,7 @@
 #ifndef ISOBUFFER_H
 #define ISOBUFFER_H
 
+// TODO: Move headers used only in implementation to isobuffer.cpp
 #include <QWidget>
 #include <QString>
 #include <QByteArray>
@@ -18,46 +19,77 @@ class isoDriver;
 class uartStyleDecoder;
 enum class UartParity : uint8_t;
 
-//isoBuffer is a generic class that enables O(1) read times (!!!) on all read/write operations, while maintaining a huge buffer size.
-//Imagine it as a circular buffer, but with access functions specifically designed for isochronous data from an Xmega.
+// isoBuffer is a generic class that enables O(1) read times (!!!) on all
+// read/write operations, while maintaining a huge buffer size.
+// Imagine it as a circular buffer, but with access functions specifically
+// designed for isochronous data from an Xmega.
 
 #define CONSOLE_UPDATE_TIMER_PERIOD (ISO_PACKETS_PER_CTX * 4)
 
+// TODO: Make private what should be private
 class isoBuffer : public QWidget
 {
     Q_OBJECT
 public:
     isoBuffer(QWidget *parent = 0, int bufferLen = 0, isoDriver *caller = 0, unsigned char channel_value = 0);
-    //Generic Functions
+    // TODO?: Add a destructor
+	
+	//Generic Functions
     void openFile(QString newFile);
-    void writeBuffer_char(char *data, int len);
-    void writeBuffer_short(short *data, int len);
-    short *readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset);
+
+//	Basic buffer operations
+	short bufferAt(int idx);
+	void insertIntoBuffer(short item);
     void clearBuffer();
     void gainBuffer(int gain_log);
-    void glitchInsert(short type);
+    void glitchInsert(short type); // NO-OP
+	
+// Advanced buffer operations
+	void writeBuffer_char(char *data, int len);
+    void writeBuffer_short(short *data, int len);
+
+    short *readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset);
+	
+//	file I/O
+	bool maybeOutputSampleToFile(double convertedSample);
     double sampleConvert(short sample, int TOP, bool AC);
     short inverseSampleConvert(double voltageLevel, int TOP, bool AC);
-    int cap_x0fromLast(double seconds, double vbot);
+
+	int cap_x0fromLast(double seconds, double vbot);
     int cap_x1fromLast(double seconds, int x0, double vbot);
     int cap_x2fromLast(double seconds, int x1, double vtop);
     void serialManage(double baudRate, int type, UartParity parity);
-    //Generic Vars
+
+// ---- MEMBER VARIABLES ----
+
+//	Presentantion?
     QPlainTextEdit *console1, *console2;
     bool serialAutoScroll = true;
     unsigned char channel = 255;
+
+// Conversion And Sampling
     double voltage_ref = 1.65;
     double frontendGain = (R4 / (R3 + R4));
     int samplesPerSecond;
     int sampleRate_bit;
-    int bufferEnd, back = 0;
-    short *buffer, *readData = NULL;
-    uartStyleDecoder *decoder = NULL;
+
+//	Internal Storage
+	int bufferEnd, back = 0;
+    short *buffer;
+
+	short *readData = NULL;
+
+//	UARTS decoding
+	uartStyleDecoder *decoder = NULL;
+	// TODO: change this to keepDecoding
     bool stopDecoding = false;
 private:
-    //Generic Vars
-    bool firstTime = true;
-    //File I/O
+    
+//	Represents wether or not we have already gone around the buffer
+	// NOTE: Appears to be unused: maybe it should be removed?
+	bool firstTime = true;
+
+//	File I/O
     bool fileIOEnabled = false;
     FILE* fptr = NULL;
     QFile *currentFile;
@@ -65,7 +97,6 @@ private:
     int fileIO_sampleCount;
     qulonglong fileIO_max_file_size;
     qulonglong fileIO_numBytesWritten;
-    //isoDriver *parent;
     unsigned int currentColumn = 0;
     isoDriver *virtualParent;
     double average_sample_temp;

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -25,7 +25,7 @@ enum class UartParity : uint8_t;
 // Imagine it as a circular buffer, but with access functions specifically
 // designed for isochronous data from an Xmega.
 
-#define CONSOLE_UPDATE_TIMER_PERIOD (ISO_PACKETS_PER_CTX * 4)
+constexpr auto CONSOLE_UPDATE_TIMER_PERIOD = ISO_PACKETS_PER_CTX * 4;
 
 // TODO: Make private what should be private
 // TODO: Add m_ prefix to member variables

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -38,7 +38,7 @@ public:
 	void openFile(QString newFile);
 
 //	Basic buffer operations
-	short bufferAt(int idx);
+	short bufferAt(int idx) const;
 	void insertIntoBuffer(short item);
 	void clearBuffer();
 	void gainBuffer(int gain_log);
@@ -52,8 +52,8 @@ public:
 	
 //	file I/O
 	bool maybeOutputSampleToFile(double convertedSample);
-	double sampleConvert(short sample, int TOP, bool AC);
-	short inverseSampleConvert(double voltageLevel, int TOP, bool AC);
+	double sampleConvert(short sample, int TOP, bool AC) const;
+	short inverseSampleConvert(double voltageLevel, int TOP, bool AC) const;
 
 	int cap_x0fromLast(double seconds, double vbot);
 	int cap_x1fromLast(double seconds, int x0, double vbot);

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -1,6 +1,7 @@
 #ifndef ISOBUFFER_H
 #define ISOBUFFER_H
 
+// TODO: Make object macros constexprs or globals
 // TODO: Move headers used only in implementation to isobuffer.cpp
 #include <QWidget>
 #include <QString>
@@ -27,10 +28,13 @@ enum class UartParity : uint8_t;
 #define CONSOLE_UPDATE_TIMER_PERIOD (ISO_PACKETS_PER_CTX * 4)
 
 // TODO: Make private what should be private
+// TODO: Add m_ prefix to member variables
+// TODO: Change integer types to cstdint types
 class isoBuffer : public QWidget
 {
 	Q_OBJECT
 public:
+	// TODO: Add consoles as constructor arguments
 	isoBuffer(QWidget* parent = 0, int bufferLen = 0, isoDriver* caller = 0, unsigned char channel_value = 0);
 	// TODO?: Add a destructor
 
@@ -48,6 +52,7 @@ public:
 	void writeBuffer_char(char* data, int len);
 	void writeBuffer_short(short* data, int len);
 
+	// TODO: Change return value to unique_ptr
 	short* readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset);
 
 //	file I/O
@@ -83,6 +88,7 @@ public:
 	int back = 0;
 	int insertedCount = 0;
 	int bufferEnd;
+// TODO: Change buffer to be a unique_ptr
 	short* buffer;
 	short* readData = NULL;
 

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -73,41 +73,41 @@ public:
 
 //	Presentantion?
 // NOTE: it seems like these are never initialized but they are used as though they were...
-	QPlainTextEdit* console1;
-	QPlainTextEdit* console2;
-	unsigned char channel = 255;
-	bool serialAutoScroll = true;
+	QPlainTextEdit* m_console1;
+	QPlainTextEdit* m_console2;
+	unsigned char m_channel = 255;
+	bool m_serialAutoScroll = true;
 
 // Conversion And Sampling
-	double voltage_ref = 1.65;
-	double frontendGain = (R4 / (R3 + R4));
-	int samplesPerSecond;
-	int sampleRate_bit;
+	double m_voltage_ref = 1.65;
+	double m_frontendGain = (R4 / (R3 + R4));
+	int m_samplesPerSecond;
+	int m_sampleRate_bit;
 
 //	Internal Storage
-	int back = 0;
-	int insertedCount = 0;
-	int bufferEnd;
+	int m_back = 0;
+	int m_insertedCount = 0;
+	int m_bufferEnd;
 // TODO: Change buffer to be a unique_ptr
-	short* buffer;
-	short* readData = NULL;
+	short* m_buffer;
+	short* m_readData = NULL;
 
 //	UARTS decoding
-	uartStyleDecoder* decoder = NULL;
+	uartStyleDecoder* m_decoder = NULL;
 	// TODO: change this to keepDecoding
-	bool stopDecoding = false;
+	bool m_stopDecoding = false;
 private:
 //	File I/O
-	bool fileIOEnabled = false;
-	FILE* fptr = NULL;
-	QFile* currentFile;
-	int fileIO_maxIncrementedSampleValue;
-	int fileIO_sampleCount;
-	qulonglong fileIO_max_file_size;
-	qulonglong fileIO_numBytesWritten;
-	unsigned int currentColumn = 0;
-	isoDriver* virtualParent;
-	double average_sample_temp;
+	bool m_fileIOEnabled = false;
+	FILE* m_fptr = NULL;
+	QFile* m_currentFile;
+	int m_fileIO_maxIncrementedSampleValue;
+	int m_fileIO_sampleCount;
+	qulonglong m_fileIO_max_file_size;
+	qulonglong m_fileIO_numBytesWritten;
+	unsigned int m_currentColumn = 0;
+	isoDriver* m_virtualParent;
+	double m_average_sample_temp;
 signals:
 	void fileIOinternalDisable();
 public slots:

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -31,75 +31,76 @@ class isoBuffer : public QWidget
 {
     Q_OBJECT
 public:
-    isoBuffer(QWidget *parent = 0, int bufferLen = 0, isoDriver *caller = 0, unsigned char channel_value = 0);
-    // TODO?: Add a destructor
-	
+	isoBuffer(QWidget *parent = 0, int bufferLen = 0, isoDriver *caller = 0, unsigned char channel_value = 0);
+	// TODO?: Add a destructor
+
 	//Generic Functions
-    void openFile(QString newFile);
+	void openFile(QString newFile);
 
 //	Basic buffer operations
 	short bufferAt(int idx);
 	void insertIntoBuffer(short item);
-    void clearBuffer();
-    void gainBuffer(int gain_log);
-    void glitchInsert(short type); // NO-OP
+	void clearBuffer();
+	void gainBuffer(int gain_log);
+	void glitchInsert(short type); // NO-OP
 	
 // Advanced buffer operations
 	void writeBuffer_char(char *data, int len);
-    void writeBuffer_short(short *data, int len);
+	void writeBuffer_short(short *data, int len);
 
-    short *readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset);
+	short *readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset);
 	
 //	file I/O
 	bool maybeOutputSampleToFile(double convertedSample);
-    double sampleConvert(short sample, int TOP, bool AC);
-    short inverseSampleConvert(double voltageLevel, int TOP, bool AC);
+	double sampleConvert(short sample, int TOP, bool AC);
+	short inverseSampleConvert(double voltageLevel, int TOP, bool AC);
 
 	int cap_x0fromLast(double seconds, double vbot);
-    int cap_x1fromLast(double seconds, int x0, double vbot);
-    int cap_x2fromLast(double seconds, int x1, double vtop);
-    void serialManage(double baudRate, int type, UartParity parity);
+	int cap_x1fromLast(double seconds, int x0, double vbot);
+	int cap_x2fromLast(double seconds, int x1, double vtop);
+	void serialManage(double baudRate, int type, UartParity parity);
 
 // ---- MEMBER VARIABLES ----
 
 //	Presentantion?
-    QPlainTextEdit *console1, *console2;
-    bool serialAutoScroll = true;
-    unsigned char channel = 255;
+// NOTE: it seems like these are never initialized but they are used as though they were...
+	QPlainTextEdit *console1, *console2;
+	unsigned char channel = 255;
+	bool serialAutoScroll = true;
 
 // Conversion And Sampling
-    double voltage_ref = 1.65;
-    double frontendGain = (R4 / (R3 + R4));
-    int samplesPerSecond;
-    int sampleRate_bit;
+	double voltage_ref = 1.65;
+	double frontendGain = (R4 / (R3 + R4));
+	int samplesPerSecond;
+	int sampleRate_bit;
 
 //	Internal Storage
-	int bufferEnd, back = 0;
-    short *buffer;
-
+	int back = 0;
+	int bufferEnd;
+	short *buffer;
 	short *readData = NULL;
 
 //	UARTS decoding
 	uartStyleDecoder *decoder = NULL;
 	// TODO: change this to keepDecoding
-    bool stopDecoding = false;
+	bool stopDecoding = false;
 private:
 //	File I/O
-    bool fileIOEnabled = false;
-    FILE* fptr = NULL;
-    QFile *currentFile;
-    int fileIO_maxIncrementedSampleValue;
-    int fileIO_sampleCount;
-    qulonglong fileIO_max_file_size;
-    qulonglong fileIO_numBytesWritten;
-    unsigned int currentColumn = 0;
-    isoDriver *virtualParent;
-    double average_sample_temp;
+	bool fileIOEnabled = false;
+	FILE* fptr = NULL;
+	QFile *currentFile;
+	int fileIO_maxIncrementedSampleValue;
+	int fileIO_sampleCount;
+	qulonglong fileIO_max_file_size;
+	qulonglong fileIO_numBytesWritten;
+	unsigned int currentColumn = 0;
+	isoDriver *virtualParent;
+	double average_sample_temp;
 signals:
-    void fileIOinternalDisable();
+	void fileIOinternalDisable();
 public slots:
-    void enableFileIO(QFile *file, int samplesToAverage, qulonglong max_file_size);
-    void disableFileIO();
+	void enableFileIO(QFile *file, int samplesToAverage, qulonglong max_file_size);
+	void disableFileIO();
 };
 
 #endif // ISOBUFFER_H

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -63,7 +63,7 @@ public:
 	int cap_x0fromLast(double seconds, double vbot);
 	int cap_x1fromLast(double seconds, int x0, double vbot);
 	int cap_x2fromLast(double seconds, int x1, double vtop);
-	void serialManage(double baudRate, int type, UartParity parity);
+	void serialManage(double baudRate, UartParity parity);
 
 // ---- MEMBER VARIABLES ----
 

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -39,7 +39,6 @@ public:
 	void insertIntoBuffer(short item);
 	void clearBuffer();
 	void gainBuffer(int gain_log);
-	void glitchInsert(short type); // NO-OP
 
 // Advanced buffer operations
 private:

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -93,7 +93,7 @@ void isoDriver::timerTick(void){
             internalBuffer375_CH2->channel = 1;
             frameActionGeneric(1,2);
             if(serialDecodeEnabled_CH1 && serialType == 0){
-                internalBuffer375_CH2->serialManage(baudRate_CH1, 0, parity_CH1);
+                internalBuffer375_CH2->serialManage(baudRate_CH1, parity_CH1);
             }
             break;
         case 2:
@@ -110,7 +110,7 @@ void isoDriver::timerTick(void){
 
             frameActionGeneric(2,0);
             if(serialDecodeEnabled_CH1 && serialType == 0){
-                internalBuffer375_CH1->serialManage(baudRate_CH1, 0, parity_CH1);
+                internalBuffer375_CH1->serialManage(baudRate_CH1, parity_CH1);
             }
             break;
         case 4:
@@ -122,10 +122,10 @@ void isoDriver::timerTick(void){
             internalBuffer375_CH2->channel = 2;
             frameActionGeneric(2,2);
             if(serialDecodeEnabled_CH1 && serialType == 0){
-                internalBuffer375_CH1->serialManage(baudRate_CH1, 0, parity_CH1);
+                internalBuffer375_CH1->serialManage(baudRate_CH1, parity_CH1);
             }
             if(serialDecodeEnabled_CH2 && serialType == 0){
-                internalBuffer375_CH2->serialManage(baudRate_CH2, 0, parity_CH2);
+                internalBuffer375_CH2->serialManage(baudRate_CH2, parity_CH2);
             }
             if (serialDecodeEnabled_CH1 && serialType == 1)
             {

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -90,7 +90,7 @@ void isoDriver::timerTick(void){
             if (deviceMode_prev != 1)
                 clearBuffers(false, true, false);
 
-            internalBuffer375_CH2->channel = 1;
+            internalBuffer375_CH2->m_channel = 1;
             frameActionGeneric(1,2);
             if(serialDecodeEnabled_CH1 && serialType == 0){
                 internalBuffer375_CH2->serialManage(baudRate_CH1, parity_CH1);
@@ -119,7 +119,7 @@ void isoDriver::timerTick(void){
             if (deviceMode_prev != 4)
                 clearBuffers(false, true, false);
 
-            internalBuffer375_CH2->channel = 2;
+            internalBuffer375_CH2->m_channel = 2;
             frameActionGeneric(2,2);
             if(serialDecodeEnabled_CH1 && serialType == 0){
                 internalBuffer375_CH1->serialManage(baudRate_CH1, parity_CH1);
@@ -1169,7 +1169,7 @@ void isoDriver::multimeterStats(){
         qDebug() << "x2 = " << cap_x2;
         qDebug() << "dt = " << cap_x2-cap_x1;
 
-        double dt = (double)(cap_x2-cap_x1)/internalBuffer375_CH1->samplesPerSecond;
+        double dt = (double)(cap_x2-cap_x1)/internalBuffer375_CH1->m_samplesPerSecond;
         double Cm = -dt/(seriesResistance * log((vcc-cap_vtop)/(vcc-cap_vbot)));
         qDebug() << "Cm = " << Cm;
 
@@ -1555,7 +1555,7 @@ void isoDriver::setSerialType(unsigned char type)
     {
         if (twoWire)
             delete twoWire;
-        twoWire = new i2c::i2cDecoder(internalBuffer375_CH1, internalBuffer375_CH2, internalBuffer375_CH1->console1);
+        twoWire = new i2c::i2cDecoder(internalBuffer375_CH1, internalBuffer375_CH2, internalBuffer375_CH1->m_console1);
     }
 }
 

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -41,11 +41,11 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->voltageInfoRmsDisplay_CH1->display(6.00);
     connectDisplaySignals();
 
-    ui->controller_iso->internalBuffer375_CH1->console1 = ui->console1;
-    ui->controller_iso->internalBuffer375_CH1->console2 = ui->console2;
+    ui->controller_iso->internalBuffer375_CH1->m_console1 = ui->console1;
+    ui->controller_iso->internalBuffer375_CH1->m_console2 = ui->console2;
 
-    ui->controller_iso->internalBuffer375_CH2->console1 = ui->console1;
-    ui->controller_iso->internalBuffer375_CH2->console2 = ui->console2;
+    ui->controller_iso->internalBuffer375_CH2->m_console1 = ui->console1;
+    ui->controller_iso->internalBuffer375_CH2->m_console2 = ui->console2;
     initShortcuts();
 
     ui->debugButton1->setVisible(0);
@@ -1204,12 +1204,12 @@ void MainWindow::readSettingsFile(){
     ui->controller_iso->ch2_ref = 3.3 - calibrate_vref_ch2;
     ui->controller_iso->frontendGain_CH1 = calibrate_gain_ch1;
     ui->controller_iso->frontendGain_CH2 = calibrate_gain_ch2;
-    ui->controller_iso->internalBuffer375_CH1->voltage_ref = 3.3 - calibrate_vref_ch1;
-    ui->controller_iso->internalBuffer750->voltage_ref = 3.3 - calibrate_vref_ch1;
-    ui->controller_iso->internalBuffer375_CH2->voltage_ref = 3.3 - calibrate_vref_ch2;
-    ui->controller_iso->internalBuffer375_CH1->frontendGain = calibrate_gain_ch1;
-    ui->controller_iso->internalBuffer750->frontendGain = calibrate_gain_ch1;
-    ui->controller_iso->internalBuffer375_CH2->frontendGain = calibrate_gain_ch2;
+    ui->controller_iso->internalBuffer375_CH1->m_voltage_ref = 3.3 - calibrate_vref_ch1;
+    ui->controller_iso->internalBuffer750->m_voltage_ref = 3.3 - calibrate_vref_ch1;
+    ui->controller_iso->internalBuffer375_CH2->m_voltage_ref = 3.3 - calibrate_vref_ch2;
+    ui->controller_iso->internalBuffer375_CH1->m_frontendGain = calibrate_gain_ch1;
+    ui->controller_iso->internalBuffer750->m_frontendGain = calibrate_gain_ch1;
+    ui->controller_iso->internalBuffer375_CH2->m_frontendGain = calibrate_gain_ch2;
 
     if(!dt_AlreadyAskedAboutCalibration && ((calibrate_vref_ch1 == 1.65) || (calibrate_vref_ch2 == 1.65) || (calibrate_gain_ch1 == R4/(R3+R4)) || (calibrate_gain_ch2 == R4/(R3+R4)))){
         //Prompt user to calibrate if no calibration data found.
@@ -1698,12 +1698,12 @@ void MainWindow::on_actionCalibrate_triggered()
     ui->controller_iso->ch2_ref = 1.65;
     ui->controller_iso->frontendGain_CH1 = (R4/(R3+R4));
     ui->controller_iso->frontendGain_CH2 = (R4/(R3+R4));
-    ui->controller_iso->internalBuffer375_CH1->voltage_ref = 1.65;
-    ui->controller_iso->internalBuffer750->voltage_ref = 1.65;
-    ui->controller_iso->internalBuffer375_CH2->voltage_ref = 1.65;
-    ui->controller_iso->internalBuffer375_CH1->frontendGain = R4/(R3+R4);
-    ui->controller_iso->internalBuffer750->frontendGain = R4/(R3+R4);
-    ui->controller_iso->internalBuffer375_CH2->frontendGain = R4/(R3+R4);
+    ui->controller_iso->internalBuffer375_CH1->m_voltage_ref = 1.65;
+    ui->controller_iso->internalBuffer750->m_voltage_ref = 1.65;
+    ui->controller_iso->internalBuffer375_CH2->m_voltage_ref = 1.65;
+    ui->controller_iso->internalBuffer375_CH1->m_frontendGain = R4/(R3+R4);
+    ui->controller_iso->internalBuffer750->m_frontendGain = R4/(R3+R4);
+    ui->controller_iso->internalBuffer375_CH2->m_frontendGain = R4/(R3+R4);
 
     settings->setValue("CalibrateVrefCH1", 1.65);
     settings->setValue("CalibrateVrefCH2", 1.65);
@@ -1733,9 +1733,9 @@ void MainWindow::calibrateStage2(){
     ui->controller_iso->ch1_ref = 3.3 - vref_CH1;
     ui->controller_iso->ch2_ref = 3.3 - vref_CH2;
 
-    ui->controller_iso->internalBuffer375_CH1->voltage_ref = 3.3 - vref_CH1;
-    ui->controller_iso->internalBuffer750->voltage_ref = 3.3 - vref_CH1;
-    ui->controller_iso->internalBuffer375_CH2->voltage_ref = 3.3 - vref_CH2;
+    ui->controller_iso->internalBuffer375_CH1->m_voltage_ref = 3.3 - vref_CH1;
+    ui->controller_iso->internalBuffer750->m_voltage_ref = 3.3 - vref_CH1;
+    ui->controller_iso->internalBuffer375_CH2->m_voltage_ref = 3.3 - vref_CH2;
 
     settings->setValue("CalibrateVrefCH1", vref_CH1);
     settings->setValue("CalibrateVrefCH2", vref_CH2);
@@ -1769,9 +1769,9 @@ void MainWindow::calibrateStage3(){
     ui->controller_iso->frontendGain_CH2 = (vref_CH2 - vMeasured_CH2)*(ui->controller_iso->frontendGain_CH2)/vref_CH2;
     qDebug() << "New gain (CH1) = " << ui->controller_iso->frontendGain_CH1;
 
-    ui->controller_iso->internalBuffer375_CH1->frontendGain = (vref_CH1 - vMeasured_CH1)*(ui->controller_iso->frontendGain_CH1)/vref_CH1;
-    ui->controller_iso->internalBuffer750->frontendGain = (vref_CH1 - vMeasured_CH1)*(ui->controller_iso->frontendGain_CH1)/vref_CH1;
-    ui->controller_iso->internalBuffer375_CH2->frontendGain = (vref_CH2 - vMeasured_CH2)*(ui->controller_iso->frontendGain_CH2)/vref_CH2;
+    ui->controller_iso->internalBuffer375_CH1->m_frontendGain = (vref_CH1 - vMeasured_CH1)*(ui->controller_iso->frontendGain_CH1)/vref_CH1;
+    ui->controller_iso->internalBuffer750->m_frontendGain = (vref_CH1 - vMeasured_CH1)*(ui->controller_iso->frontendGain_CH1)/vref_CH1;
+    ui->controller_iso->internalBuffer375_CH2->m_frontendGain = (vref_CH2 - vMeasured_CH2)*(ui->controller_iso->frontendGain_CH2)/vref_CH2;
     settings->setValue("CalibrateGainCH1", ui->controller_iso->frontendGain_CH1);
     settings->setValue("CalibrateGainCH2", ui->controller_iso->frontendGain_CH2);
     calibrationMessages->setText("Oscilloscope Calibration complete.");


### PR DESCRIPTION
I had a go at refactoring isoBuffer. The main benefit is that i managed to reduce duplication, and that i managed to make the logic in some of these functions simpler.

I also added some comments which will hopefully make isoBuffer easier to mantain in the future.

There are a few caveats though:
~First, I did not go over the isoBuffer::cap_xnfromLast family of functions but i believe that these can be simplified and DRYed up quite easily.~
And second, i went pretty hard on isoBuffer::readBuffer, and it ended up not resembling the original function much or at all. I fear it no longer does the same thing it used to do... I tested it a bit and i think it's fine but i can't tell for sure. I added a comment explaining what i think this function is meant to do, and my implementation seems to do what i want (that is, it passes my tests). But I'm still quite unsure.

EDIT: I have gone through and further removed duplication by extracting the common functionality of cap_x0fromLast, cap_x1fromLast, and cap_x2fromLast to a separate function, capSample. Since this function shouldn't really be accesible from anywhere else, it is declared and defined in isoBuffer.cpp