### PR TITLE
Isobuffer refactor - part 2

### DIFF
--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -25,7 +25,7 @@ namespace
 isoBuffer::isoBuffer(QWidget* parent, int bufferLen, isoDriver* caller, unsigned char channel_value)
 	: QWidget(parent)
 	, m_channel(channel_value)
-	, m_buffer((short*)calloc(bufferLen*2, sizeof(short)))
+	, m_buffer(std::make_unique<short[]>(bufferLen*2))
 	, m_bufferEnd(bufferLen-1)
 	, m_samplesPerSecond(bufferLen/21.0/375*VALID_DATA_PER_375)
 	, m_sampleRate_bit(bufferLen/21.0/375*VALID_DATA_PER_375*8)
@@ -35,7 +35,6 @@ isoBuffer::isoBuffer(QWidget* parent, int bufferLen, isoDriver* caller, unsigned
 
 isoBuffer::~isoBuffer()
 {
-	free(m_buffer);
 	free(m_readData);
 }
 

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -37,7 +37,7 @@ isoBuffer::isoBuffer(QWidget* parent, int bufferLen, isoDriver* caller, unsigned
 void isoBuffer::insertIntoBuffer(short item)
 {
 	m_buffer[m_back] = item;
-	m_buffer[m_back+m_bufferEnd+1];
+	m_buffer[m_back+m_bufferEnd+1] = item;
 	m_back++;
 	m_insertedCount++;
 

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -331,10 +331,10 @@ void isoBuffer::serialManage(double baudRate, UartParity parity)
 		connect(m_decoder, &uartStyleDecoder::wireDisconnected,
 		        m_virtualParent, &isoDriver::serialNeedsDisabling);
 	}
-	if (m_stopDecoding)
+	if (!m_isDecoding)
 	{
 		m_decoder->updateTimer->start(CONSOLE_UPDATE_TIMER_PERIOD);
-		m_stopDecoding = false;
+		m_isDecoding = true;
 	}
 	m_decoder->setParityMode(parity);
 	m_decoder->serialDecode(baudRate);

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -278,6 +278,8 @@ short isoBuffer::inverseSampleConvert(double voltageLevel, int TOP, bool AC) con
 	return sample;
 }
 
+// For capacitance measurement. x0, x1 and x2 are all various time points
+// used to find the RC coefficient.
 template<typename Function>
 int isoBuffer::capSample(int offset, int target, double seconds, double value, Function comp)
 {
@@ -303,8 +305,6 @@ int isoBuffer::capSample(int offset, int target, double seconds, double value, F
 	return -1;
 }
 
-// For capacitance measurement. x0, x1 and x2 are all various time points
-// used to find the RC coefficient.
 int isoBuffer::cap_x0fromLast(double seconds, double vbot)
 {
 	return capSample(0, kSamplesSeekingCap, seconds, vbot, fX0Comp);

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -149,8 +149,6 @@ short* isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit
 	 * The expected behavior is to cycle backwards over the buffer, taking into
 	 * acount only the part of the buffer that has things stored, with a stride
 	 * of timeBetweenSamples steps, and push the touched elements into readData.
-	 *
-	 * ~Sebastian Mestre
 	 */
 	const double timeBetweenSamples = sampleWindow * m_samplesPerSecond / numSamples;
 	const int delaySamples = delayOffset * m_samplesPerSecond;

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -33,9 +33,11 @@ isoBuffer::isoBuffer(QWidget* parent, int bufferLen, isoDriver* caller, unsigned
 {
 }
 
+// NOTE: the length of half of the allocated buffer is m_bufferEnd+1
 void isoBuffer::insertIntoBuffer(short item)
 {
 	m_buffer[m_back] = item;
+	m_buffer[m_back+m_bufferEnd+1];
 	m_back++;
 	m_insertedCount++;
 
@@ -52,7 +54,8 @@ void isoBuffer::insertIntoBuffer(short item)
 
 short isoBuffer::bufferAt(int idx) const
 {
-	return m_buffer[m_back - idx];
+	// NOTE: this is only correct if idx < m_insertedCount
+	return m_buffer[m_back + (m_bufferEnd+1) - idx];
 }
 
 void isoBuffer::outputSampleToFile(double averageSample)

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -24,13 +24,19 @@ namespace
 
 isoBuffer::isoBuffer(QWidget* parent, int bufferLen, isoDriver* caller, unsigned char channel_value)
 	: QWidget(parent)
+	, m_channel(channel_value)
 	, m_buffer((short*)calloc(bufferLen*2, sizeof(short)))
 	, m_bufferEnd(bufferLen-1)
 	, m_samplesPerSecond(bufferLen/21.0/375*VALID_DATA_PER_375)
 	, m_sampleRate_bit(bufferLen/21.0/375*VALID_DATA_PER_375*8)
 	, m_virtualParent(caller)
-	, m_channel(channel_value)
 {
+}
+
+isoBuffer::~isoBuffer()
+{
+	free(m_buffer);
+	free(m_readData);
 }
 
 // NOTE: the length of half of the allocated buffer is m_bufferEnd+1

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -152,16 +152,14 @@ std::unique_ptr<short[]> isoBuffer::readBuffer(double sampleWindow, int numSampl
 	 * of timeBetweenSamples steps, and push the touched elements into readData.
 	 * If more elements are requested than how many are stored (1), the buffer
 	 * will be populated only partially. Modifying this function to return null
-	 * or a zero-filled buffer insted should be simple enough.
+	 * or a zero-filled buffer instead should be simple enough.
 	 *
 	 * (1) m_insertedCount < (delayOffset + sampleWindow) * m_samplesPerSecond
-	 *
-	 * If this is not the intent, please let me know.
 	 */
 	const double timeBetweenSamples = sampleWindow * m_samplesPerSecond / numSamples;
 	const int delaySamples = delayOffset * m_samplesPerSecond;
 
-	auto readData = std::make_unique<short[]>(numSamples);
+	std::unique_ptr<short[]> readData = std::make_unique<short[]>(numSamples);
 
 	std::fill (readData.get(), readData.get() + numSamples, short(0));
 

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -63,7 +63,7 @@ void isoBuffer::outputSampleToFile(double averageSample)
 		m_currentFile->write(numStr);
 		m_currentColumn++;
 
-		if (m_currentColumn >= COLUMN_BREAK)
+		if (m_currentColumn == COLUMN_BREAK)
 		{
 			m_currentFile->write("\n");
 			m_currentColumn = 0;
@@ -326,10 +326,9 @@ void isoBuffer::serialManage(double baudRate, UartParity parity)
 	if (m_decoder == NULL)
 	{
 		m_decoder = new uartStyleDecoder(this);
-		// TODO: Look into using the type safe version of connect.
-		// NOTE: I believe Qt has a type-safe version of this, without the macros and the
-		// explicit signature and stuff, i think it uses member-function pointers instead.
-		connect(m_decoder, SIGNAL(wireDisconnected(int)), m_virtualParent, SLOT(serialNeedsDisabling(int)));
+
+		connect(m_decoder, &uartStyleDecoder::wireDisconnected,
+		        m_virtualParent, &isoDriver::serialNeedsDisabling);
 	}
 	if (m_stopDecoding)
 	{

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -145,7 +145,7 @@ void isoBuffer::writeBuffer_short(short* data, int len)
 	writeBuffer(data, len, 2048, [](short item) -> short {return item >> 4;});
 }
 
-short* isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset)
+std::unique_ptr<short[]> isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset)
 {
 	/*
 	 * The expected behavior is to run backwards over the buffer with a stride
@@ -179,7 +179,7 @@ short* isoBuffer::readBuffer(double sampleWindow, int numSamples, bool singleBit
 		itr += timeBetweenSamples;
 	}
 
-	return readData.release();
+	return readData;
 }
 
 void isoBuffer::clearBuffer()

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -1,7 +1,6 @@
 #ifndef ISOBUFFER_H
 #define ISOBUFFER_H
 
-// TODO: Make object macros constexprs or globals
 // TODO: Move headers used only in implementation to isobuffer.cpp
 #include <QWidget>
 #include <QString>
@@ -28,7 +27,6 @@ enum class UartParity : uint8_t;
 constexpr uint32_t CONSOLE_UPDATE_TIMER_PERIOD = ISO_PACKETS_PER_CTX * 4;
 
 // TODO: Make private what should be private
-// TODO: Add m_ prefix to member variables
 // TODO: Change integer types to cstdint types
 class isoBuffer : public QWidget
 {
@@ -75,25 +73,25 @@ public:
 // ---- MEMBER VARIABLES ----
 
 //	Presentantion?
-// NOTE: it seems like these are never initialized but they are used as though they were...
+// NOTE: These are initialized in mainwindow.cpp
 	QPlainTextEdit* m_console1;
 	QPlainTextEdit* m_console2;
 	unsigned char m_channel = 255;
 	bool m_serialAutoScroll = true;
+
+//	Internal Storage
+// TODO: Change m_buffer to be a unique_ptr
+	short* m_readData = NULL;
+	short* m_buffer;
+	int m_back = 0;
+	int m_insertedCount = 0;
+	int m_bufferEnd;
 
 // Conversion And Sampling
 	double m_voltage_ref = 1.65;
 	double m_frontendGain = (R4 / (R3 + R4));
 	int m_samplesPerSecond;
 	int m_sampleRate_bit;
-
-//	Internal Storage
-	int m_back = 0;
-	int m_insertedCount = 0;
-	int m_bufferEnd;
-// TODO: Change buffer to be a unique_ptr
-	short* m_buffer;
-	short* m_readData = NULL;
 
 //	UARTS decoding
 	uartStyleDecoder* m_decoder = NULL;
@@ -102,15 +100,15 @@ public:
 private:
 //	File I/O
 	bool m_fileIOEnabled = false;
-	FILE* m_fptr = NULL;
 	QFile* m_currentFile;
-	int m_fileIO_maxIncrementedSampleValue;
+	int m_fileIO_sampleCountPerWrite;
 	int m_fileIO_sampleCount;
-	qulonglong m_fileIO_max_file_size;
+	double m_fileIO_sampleAccumulator;
+	qulonglong m_fileIO_maxFileSize;
 	qulonglong m_fileIO_numBytesWritten;
 	unsigned int m_currentColumn = 0;
+
 	isoDriver* m_virtualParent;
-	double m_average_sample_temp;
 signals:
 	void fileIOinternalDisable();
 public slots:

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -96,8 +96,7 @@ public:
 
 //	UARTS decoding
 	uartStyleDecoder* m_decoder = NULL;
-	// TODO: change this to keepDecoding
-	bool m_stopDecoding = false;
+	bool m_isDecoding = true;
 private:
 //	File I/O
 	bool m_fileIOEnabled = false;

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -56,7 +56,10 @@ public:
 	short* readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset);
 
 //	file I/O
-	bool maybeOutputSampleToFile(double convertedSample);
+private:
+	void outputSampleToFile(double averageSample);
+	void maybeOutputSampleToFile(double convertedSample);
+public:
 	double sampleConvert(short sample, int TOP, bool AC) const;
 	short inverseSampleConvert(double voltageLevel, int TOP, bool AC) const;
 

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -33,7 +33,7 @@ class isoBuffer : public QWidget
 	Q_OBJECT
 public:
 	isoBuffer(QWidget* parent = 0, int bufferLen = 0, isoDriver* caller = 0, unsigned char channel_value = 0);
-	// TODO?: Add a destructor
+	~isoBuffer();
 
 //	Basic buffer operations
 	short bufferAt(int idx) const;

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -52,7 +52,7 @@ public:
 	void writeBuffer_short(short* data, int len);
 
 	// TODO: Change return value to unique_ptr
-	short* readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset);
+	std::unique_ptr<short[]> readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset);
 
 //	file I/O
 private:

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -35,7 +35,7 @@ class isoBuffer : public QWidget
 	Q_OBJECT
 public:
 	isoBuffer(QWidget* parent = 0, int bufferLen = 0, isoDriver* caller = 0, unsigned char channel_value = 0);
-	~isoBuffer();
+	~isoBuffer() = default;
 
 //	Basic buffer operations
 	short bufferAt(int idx) const;
@@ -82,7 +82,6 @@ public:
 	bool m_serialAutoScroll = true;
 
 //	Internal Storage
-	short* m_readData = NULL;
 	std::unique_ptr<short[]> m_buffer;
 	int m_back = 0;
 	int m_insertedCount = 0;

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -51,7 +51,6 @@ public:
 	void writeBuffer_char(char* data, int len);
 	void writeBuffer_short(short* data, int len);
 
-	// TODO: Change return value to unique_ptr
 	std::unique_ptr<short[]> readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset);
 
 //	file I/O
@@ -73,7 +72,7 @@ public:
 
 // ---- MEMBER VARIABLES ----
 
-//	Presentantion?
+//	Presentation?
 // TODO: Add consoles as constructor arguments
 // NOTE: These are initialized in mainwindow.cpp
 	QPlainTextEdit* m_console1;

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -32,7 +32,6 @@ class isoBuffer : public QWidget
 {
 	Q_OBJECT
 public:
-	// TODO: Add consoles as constructor arguments
 	isoBuffer(QWidget* parent = 0, int bufferLen = 0, isoDriver* caller = 0, unsigned char channel_value = 0);
 	// TODO?: Add a destructor
 
@@ -73,6 +72,7 @@ public:
 // ---- MEMBER VARIABLES ----
 
 //	Presentantion?
+// TODO: Add consoles as constructor arguments
 // NOTE: These are initialized in mainwindow.cpp
 	QPlainTextEdit* m_console1;
 	QPlainTextEdit* m_console2;

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -2,6 +2,8 @@
 #define ISOBUFFER_H
 
 // TODO: Move headers used only in implementation to isobuffer.cpp
+#include <memory>
+
 #include <QWidget>
 #include <QString>
 #include <QByteArray>
@@ -80,9 +82,8 @@ public:
 	bool m_serialAutoScroll = true;
 
 //	Internal Storage
-// TODO: Change m_buffer to be a unique_ptr
 	short* m_readData = NULL;
-	short* m_buffer;
+	std::unique_ptr<short[]> m_buffer;
 	int m_back = 0;
 	int m_insertedCount = 0;
 	int m_bufferEnd;

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -806,23 +806,23 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)  //0 for off, 1
 
 
     if (CH1_mode == 1){
-        analogConvert(readData375_CH1, &CH1, 128, AC_CH1, 1);
+        analogConvert(readData375_CH1.get(), &CH1, 128, AC_CH1, 1);
         xmin = (currentVmin < xmin) ? currentVmin : xmin;
         xmax = (currentVmax > xmax) ? currentVmax : xmax;
         broadcastStats(0);
     }
-    if (CH1_mode == 2) digitalConvert(readData375_CH1, &CH1);
+    if (CH1_mode == 2) digitalConvert(readData375_CH1.get(), &CH1);
 
     if (CH2_mode == 1){
-        analogConvert(readData375_CH2, &CH2, 128, AC_CH2, 2);
+        analogConvert(readData375_CH2.get(), &CH2, 128, AC_CH2, 2);
         ymin = (currentVmin < ymin) ? currentVmin : ymin;
         ymax = (currentVmax > ymax) ? currentVmax : ymax;
         broadcastStats(1);
     }
-    if (CH2_mode == 2) digitalConvert(readData375_CH2, &CH2);
+    if (CH2_mode == 2) digitalConvert(readData375_CH2.get(), &CH2);
 
     if(CH1_mode == -1) {
-        analogConvert(readData750, &CH1, 128, AC_CH1, 1);
+        analogConvert(readData750.get(), &CH1, 128, AC_CH1, 1);
         xmin = (currentVmin < xmin) ? currentVmin : xmin;
         xmax = (currentVmax > xmax) ? currentVmax : xmax;
         broadcastStats(0);
@@ -947,7 +947,7 @@ void isoDriver::multimeterAction(){
     readData375_CH1 = internalBuffer375_CH1->readBuffer(window,GRAPH_SAMPLES, false, delay + ((triggerEnabled&&!paused_multimeter) ? triggerDelay + window/2 : 0));
 
     QVector<double> x(GRAPH_SAMPLES), CH1(GRAPH_SAMPLES);
-    analogConvert(readData375_CH1, &CH1, 2048, 0, 1);  //No AC coupling!
+    analogConvert(readData375_CH1.get(), &CH1, 2048, 0, 1);  //No AC coupling!
 
     for (double i=0; i<GRAPH_SAMPLES; i++){
         x[i] = -(window*i)/((double)(GRAPH_SAMPLES-1)) - delay;
@@ -1337,7 +1337,7 @@ double isoDriver::meanVoltageLast(double seconds, unsigned char channel, int TOP
         break;
     }
 
-    short * tempBuffer = currentBuffer->readBuffer(seconds,1024, 0, 0);
+	std::unique_ptr<short[]> tempBuffer = currentBuffer->readBuffer(seconds,1024, 0, 0);
     double sum = 0;
     double temp;
     for(int i = 0; i<1024; i++){

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -1337,7 +1337,7 @@ double isoDriver::meanVoltageLast(double seconds, unsigned char channel, int TOP
         break;
     }
 
-	std::unique_ptr<short[]> tempBuffer = currentBuffer->readBuffer(seconds,1024, 0, 0);
+	std::unique_ptr<short[]> tempBuffer = currentBuffer->readBuffer(seconds, 1024, 0, 0);
     double sum = 0;
     double temp;
     for(int i = 0; i<1024; i++){

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -96,7 +96,9 @@ private:
     void frameActionGeneric(char CH1_mode, char CH2_mode);
     //Variables that are just pointers to other classes/vars
     QCustomPlot *axes;
-    short *readData375_CH1, *readData375_CH2, *readData750;
+	std::unique_ptr<short[]> readData375_CH1;
+	std::unique_ptr<short[]> readData375_CH2;
+	std::unique_ptr<short[]> readData750;
     float *readDataFile;
     char *isoTemp = NULL;
     short *isoTemp_short = NULL;

--- a/Desktop_Interface/uartstyledecoder.cpp
+++ b/Desktop_Interface/uartstyledecoder.cpp
@@ -83,7 +83,7 @@ void uartStyleDecoder::serialDecode(double baudRate)
     if(allZeroes){
         qDebug() << "Wire Disconnect detected!";
         wireDisconnected(parent->m_channel);
-        parent->m_stopDecoding = true;
+        parent->m_isDecoding = false;
         updateTimer->stop();
     }
 }


### PR DESCRIPTION
Hello there, this one is quite a bit lighter than the previous one. Mostly focused on cleaning up some details that i overlooked or that i deemed would make the previous pr just waay too large.

I further cleaned up readBuffer, I believe it now does what it's suposed to do. It also returns a unique_ptr.

I think isoBuffer can be modified to allocate a buffer half as big as it does now (contiguous range queries are not needed, so a double ring buffer is not needed), but i haven't looked into that just yet since I would also have to study how other classes access m_buffer.

I changed the connect on serialManage to use member function pointers instead of the SIGNAL and SLOT macros. As far as know, this is a best practice and can be done safely and incrementaly all throughout the codebase.

I moved the storage to unique_ptr's. I don't believe there were memory leaks before, even though the buffers weren't being freed on destruction. This is because (it seems to me) all isoBuffers were alive for almost the entire runtime of the application, so the buffers were freed soon after the isoBuffers died anyways. But better safe than sorry. It also led to removing a few calls to free(), which is nice.

There are also quite a few small changes, like changing `m_stopDecoding` to `m_isDecoding` (the motivation was using a positive term for bools, to avoid confusion), reordering member variables (I wanted to have related data close together, mostly for ease of reading), using `==` instead of `>=` on the output file column comparison (to indicate that the column count goes up by one), and a bunch more, related to comments and the like.