### PR TITLE
Access the pointer directly on isoBufferBuffer::insert

### DIFF
--- a/Desktop_Interface/isobufferbuffer.cpp
+++ b/Desktop_Interface/isobufferbuffer.cpp
@@ -31,10 +31,12 @@ isoBufferBuffer::isoBufferBuffer(uint32_t length)
 // Adds a character to the end of the buffer
 void isoBufferBuffer::insert(char c)
 {
+	char* dataPtr = m_data.get();
+
 	// Add character to first half of the buffer
-	m_data[m_top] = c;
+	dataPtr[m_top] = c;
 	// Then to the second
-	m_data[m_top+m_capacity] = c;
+	dataPtr[m_top+m_capacity] = c;
 
 	// Loop the buffer index if necessary and update size accordingly
 	m_top = (m_top + 1) % m_capacity;


### PR DESCRIPTION
It came to mind after what you told me about the other place where i used unique_ptr.

I ran some benchmarks on this and `isoBufferBuffer::insert(const char*)` ended up being 2x faster than accessing the unique_ptr directly, and about 20% slower than a raw pointer with optimizer set to -O0 or -O1.

On higher optimization levels, the difference between the 3 different methods is too small to measure. This is likely due to the compiler moving the unique_ptr::get out of the loop, removing the overhead almost completely.

PS: I have a question about a particular piece of code somewhere else on the codebase. Is there a "right place" for me to ask about it? I figured spamming your email with questions without asking if that's ok first would not be a nice thing to do.