### PR TITLE
Uartstyledecoder refactor

### DIFF
--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -338,7 +338,7 @@ void isoBuffer::serialManage(double baudRate, UartParity parity)
 {
     if (m_decoder == NULL)
     {
-        m_decoder = new uartStyleDecoder(this);
+        m_decoder = new uartStyleDecoder(baudRate, this);
 
         connect(m_decoder, &uartStyleDecoder::wireDisconnected,
                 m_virtualParent, &isoDriver::serialNeedsDisabling);
@@ -348,8 +348,10 @@ void isoBuffer::serialManage(double baudRate, UartParity parity)
         m_decoder->m_updateTimer.start(CONSOLE_UPDATE_TIMER_PERIOD);
         m_isDecoding = true;
     }
+
+	m_decoder->m_baudRate = baudRate;
     m_decoder->setParityMode(parity);
-    m_decoder->serialDecode(baudRate);
+    m_decoder->serialDecode();
 }
 
 void isoBuffer::setTriggerType(TriggerType newType)

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -345,7 +345,7 @@ void isoBuffer::serialManage(double baudRate, UartParity parity)
     }
     if (!m_isDecoding)
     {
-        m_decoder->updateTimer->start(CONSOLE_UPDATE_TIMER_PERIOD);
+        m_decoder->m_updateTimer.start(CONSOLE_UPDATE_TIMER_PERIOD);
         m_isDecoding = true;
     }
     m_decoder->setParityMode(parity);

--- a/Desktop_Interface/uartstyledecoder.cpp
+++ b/Desktop_Interface/uartstyledecoder.cpp
@@ -233,16 +233,12 @@ void uartStyleDecoder::performParityCheck()
 {
     auto isEvenParity = [=] () -> bool
     {
-        uint32_t mask = 0x00000001;
-        uint8_t parity = 0;
-        for (int i = 0; i < dataBit_max; i++)
-        {
-            const uint8_t currentBit = (dataBit_current & mask) ? 1 : 0;
-            parity = parity ^ currentBit;
-            mask = mask << 1;
-        }
+		bool result = false;
 
-        return parity == 0;
+		for (uint32_t mask = 1 << (dataBit_max-1); mask != 0; mask >>= 1)
+			result ^= static_cast<bool>(dataBit_current & mask);
+
+		return not result;
     };
 
     switch(parity)

--- a/Desktop_Interface/uartstyledecoder.cpp
+++ b/Desktop_Interface/uartstyledecoder.cpp
@@ -2,29 +2,26 @@
 #include <QDebug>
 #include <cassert>
 
-uartStyleDecoder::uartStyleDecoder(QObject *parent_in)
-	: QObject(parent_in)
-	, parent{static_cast<isoBuffer*>(parent_in)}
+uartStyleDecoder::uartStyleDecoder(double baudRate, QObject *parent)
+	: QObject(parent)
+	, m_parent{static_cast<isoBuffer*>(parent)}
 	, m_serialBuffer{SERIAL_BUFFER_LENGTH}
+	, m_baudRate{baudRate}
 {
 
 	// Begin decoding SAMPLE_DELAY seconds in the past.
-	serialPtr_bit = (int)(parent->m_back * 8 - SERIAL_DELAY * parent->m_sampleRate_bit + parent->m_bufferLen * 8) % (parent->m_bufferLen*8);
+	serialPtr_bit = (int)(m_parent->m_back * 8 - SERIAL_DELAY * m_parent->m_sampleRate_bit + m_parent->m_bufferLen * 8) % (m_parent->m_bufferLen*8);
 
     m_updateTimer.setTimerType(Qt::PreciseTimer);
     m_updateTimer.start(CONSOLE_UPDATE_TIMER_PERIOD);
     connect(&m_updateTimer, &QTimer::timeout, this, &uartStyleDecoder::updateConsole);
 
-    if (parent->m_channel == 1)
-		console = parent->m_console1;
-    else if (parent->m_channel == 2)
-		console = parent->m_console2;
+    if (m_parent->m_channel == 1)
+		console = m_parent->m_console1;
+    else if (m_parent->m_channel == 2)
+		console = m_parent->m_console2;
     else
 		qFatal("Nonexistant console requested in uartStyleDecoder::serialDecode");
-}
-
-uartStyleDecoder::~uartStyleDecoder()
-{
 }
 
 void uartStyleDecoder::updateConsole()
@@ -35,7 +32,7 @@ void uartStyleDecoder::updateConsole()
     std::lock_guard<std::mutex> lock(mutex);
 
     console->setPlainText(QString::fromLocal8Bit(m_serialBuffer.begin(), m_serialBuffer.size()));
-    if (parent->m_serialAutoScroll)
+    if (m_parent->m_serialAutoScroll)
 	{
         //http://stackoverflow.com/questions/21059678/how-can-i-set-auto-scroll-for-a-qtgui-qtextedit-in-pyqt4   DANKON
         QTextCursor c = console->textCursor();
@@ -47,10 +44,10 @@ void uartStyleDecoder::updateConsole()
     //charPos = 0;
 }
 
-void uartStyleDecoder::serialDecode(double baudRate)
+void uartStyleDecoder::serialDecode()
 {
-    double dist_seconds = (double)serialDistance()/(parent->m_sampleRate_bit);
-    double bitPeriod_seconds = 1/baudRate;
+    double dist_seconds = (double)serialDistance()/(m_parent->m_sampleRate_bit);
+    double bitPeriod_seconds = 1.0 / m_baudRate;
 
     // Used to check for wire disconnects.  You should get at least one "1" for a stop bit.
     bool allZeroes = true;
@@ -58,7 +55,7 @@ void uartStyleDecoder::serialDecode(double baudRate)
     while(dist_seconds > (bitPeriod_seconds + SERIAL_DELAY))
 	{
         // Read next uart bit
-        unsigned char uart_bit = getUartBit(serialPtr_bit);
+        bool uart_bit = getNextUartBit();
 
         if (uart_bit == 1)
             allZeroes = false;
@@ -70,61 +67,64 @@ void uartStyleDecoder::serialDecode(double baudRate)
         }
         else
         {
-            uartTransmitting = uart_bit != 1;  // Uart starts transmitting after start bit (logic low).
+			// Uart starts transmitting after start bit (logic low).
+            uartTransmitting = uart_bit == false;
             jitterCompensationNeeded = true;
         }
 
         // Update the pointer, accounting for jitter
-        updateSerialPtr(baudRate, uart_bit);
+        updateSerialPtr(uart_bit);
         // Calculate stopping condition
-        dist_seconds = (double)serialDistance()/(parent->m_sampleRate_bit);
+        dist_seconds = (double)serialDistance()/(m_parent->m_sampleRate_bit);
     }
 
     //Not a single stop bit, or idle bit, in the whole stream.  Wire must be disconnected.
     if (allZeroes)
 	{
         qDebug() << "Wire Disconnect detected!";
-        wireDisconnected(parent->m_channel);
-        parent->m_isDecoding = false;
+        wireDisconnected(m_parent->m_channel);
+        m_parent->m_isDecoding = false;
         m_updateTimer.stop();
     }
 }
 
 int uartStyleDecoder::serialDistance() const
 {
-    int back_bit = parent->m_back * 8;
-    int bufferEnd_bit = (parent->m_bufferLen-1) * 8;
+    int back_bit = m_parent->m_back * 8;
+    int bufferEnd_bit = (m_parent->m_bufferLen-1) * 8;
     if (back_bit >= serialPtr_bit)
         return back_bit - serialPtr_bit;
     else
 		return bufferEnd_bit - serialPtr_bit + back_bit;
 }
 
-void uartStyleDecoder::updateSerialPtr(double baudRate, unsigned char current_bit)
+void uartStyleDecoder::updateSerialPtr(bool current_bit)
 {
     if (jitterCompensationNeeded && uartTransmitting)
-        jitterCompensationNeeded = jitterCompensationProcedure(baudRate, current_bit);
+        jitterCompensationNeeded = jitterCompensationProcedure(current_bit);
 
-    int distance_between_bits = (parent->m_sampleRate_bit)/baudRate;
+    int distance_between_bits = (m_parent->m_sampleRate_bit)/ m_baudRate;
     if (uartTransmitting)
         serialPtr_bit += distance_between_bits;
 	else
 		serialPtr_bit += (distance_between_bits - 1);  //Less than one baud period so that it will always see that start bit.
 
-    if (serialPtr_bit >= (parent->m_bufferLen * 8))
-        serialPtr_bit -= (parent->m_bufferLen * 8);
+    if (serialPtr_bit >= (m_parent->m_bufferLen * 8))
+        serialPtr_bit -= (m_parent->m_bufferLen * 8);
 }
 
-unsigned char uartStyleDecoder::getUartBit(int bitIndex) const
+bool uartStyleDecoder::getNextUartBit() const
 {
+	int bitIndex = serialPtr_bit;
+
     int coord_byte = bitIndex/8;
     int coord_bit = bitIndex - (8*coord_byte);
-    unsigned char dataByte = parent->m_buffer[coord_byte];
-    unsigned char mask = (0x01 << coord_bit);
-    return ((dataByte & mask) ? 1 : 0);
+    uint8_t dataByte = m_parent->m_buffer[coord_byte];
+    uint8_t mask = (0x01 << coord_bit);
+    return dataByte & mask;
 }
 
-void uartStyleDecoder::decodeNextUartBit(unsigned char bitValue)
+void uartStyleDecoder::decodeNextUartBit(bool bitValue)
 {
     if (dataBit_current == parityIndex)
     {
@@ -157,34 +157,34 @@ void uartStyleDecoder::decodeNextUartBit(unsigned char bitValue)
 
 //This function compensates for jitter by, when the current bit is a "1", and the last bit was a zero, setting the pointer
 //to the sample at the midpoint between this bit and the last.
-bool uartStyleDecoder::jitterCompensationProcedure(double baudRate, unsigned char current_bit)
+bool uartStyleDecoder::jitterCompensationProcedure(bool current_bit)
 {
 
     //We only run when the current bit is a "1", to prevent slowdown when there are long breaks between transmissions.
-    if (current_bit == 0)
+    if (current_bit == false)
         return true;
 
     //Can't be bothered dealing with the corner case where the serial pointer is at the very start of the buffer.
     //Just return and try again next time.
-    int left_coord = serialPtr_bit - (parent->m_sampleRate_bit)/baudRate;
+    int left_coord = serialPtr_bit - (m_parent->m_sampleRate_bit)/ m_baudRate;
     //qDebug() << "left_coord =" << left_coord;
     if (left_coord < 0)
         return true; //Don't want to read out of bounds!!
 
     //The usual case, when transmitting anyway.
-    unsigned char left_byte = (parent->m_buffer[left_coord/8] & 0xff);
+    uint8_t left_byte = (m_parent->m_buffer[left_coord/8] & 0xff);
     //Only run when a zero is detected in the leftmost symbol.
-    if (left_byte != 255)
+    if (left_byte != 0xff)
 	{
         //Step back, one sample at a time, to the 0->1 transition point
-        unsigned char temp_bit = 1;
+        bool temp_bit = 1;
         while(temp_bit)
 		{
-            temp_bit = getUartBit(serialPtr_bit);
+            temp_bit = getNextUartBit();
             serialPtr_bit--;
         }
         //Jump the pointer forward by half a uart bit period, and return "done!".
-        serialPtr_bit += (parent->m_sampleRate_bit/baudRate)/2;
+        serialPtr_bit += (m_parent->m_sampleRate_bit/ m_baudRate)/2;
         return false;
     }
 
@@ -208,7 +208,7 @@ char uartStyleDecoder::decodeDatabit(int mode, short symbol) const
     }
 }
 
-char uartStyleDecoder::decodeBaudot([[maybe_unused]] short symbol) const
+char uartStyleDecoder::decodeBaudot(short symbol) const
 {
     return 'a';
 }

--- a/Desktop_Interface/uartstyledecoder.cpp
+++ b/Desktop_Interface/uartstyledecoder.cpp
@@ -209,7 +209,7 @@ void uartStyleDecoder::decodeDatabit(int mode)
     m_serialBuffer.insert(tempchar);
 }
 
-char uartStyleDecoder::decode_baudot(short symbol)
+char uartStyleDecoder::decode_baudot([[maybe_unused]] short symbol)
 {
     return 'a';
 }
@@ -231,12 +231,12 @@ void uartStyleDecoder::setParityMode(UartParity newParity)
 
 void uartStyleDecoder::performParityCheck()
 {
-    auto isEvenParity = [=] () -> bool
+    auto isEvenParity = [=] (uint32_t bitField) -> bool
     {
 		bool result = false;
 
 		for (uint32_t mask = 1 << (dataBit_max-1); mask != 0; mask >>= 1)
-			result ^= static_cast<bool>(dataBit_current & mask);
+			result ^= static_cast<bool>(bitField & mask);
 
 		return not result;
     };
@@ -247,10 +247,10 @@ void uartStyleDecoder::performParityCheck()
 		std::terminate();
         break;
     case UartParity::Even:
-        parityCheckFailed = !isEvenParity();
-		// NOTE: Missing a break?
+        parityCheckFailed = not isEvenParity(dataBit_current);
+		break; // NOTE: There used to be a fallthrough here but it seemed like a bug
     case UartParity::Odd:
-        parityCheckFailed = isEvenParity();
+        parityCheckFailed = isEvenParity(dataBit_current);
 		break;
     }
 

--- a/Desktop_Interface/uartstyledecoder.cpp
+++ b/Desktop_Interface/uartstyledecoder.cpp
@@ -93,7 +93,7 @@ void uartStyleDecoder::serialDecode(double baudRate)
     }
 }
 
-int uartStyleDecoder::serialDistance()
+int uartStyleDecoder::serialDistance() const
 {
     int back_bit = parent->m_back * 8;
     int bufferEnd_bit = (parent->m_bufferLen-1) * 8;
@@ -118,7 +118,7 @@ void uartStyleDecoder::updateSerialPtr(double baudRate, unsigned char current_bi
         serialPtr_bit -= (parent->m_bufferLen * 8);
 }
 
-unsigned char uartStyleDecoder::getNextUartBit()
+unsigned char uartStyleDecoder::getNextUartBit() const
 {
     int coord_byte = serialPtr_bit/8;
     int coord_bit = serialPtr_bit - (8*coord_byte);
@@ -193,7 +193,7 @@ void uartStyleDecoder::decodeDatabit(int mode)
     switch(mode)
 	{
         case 5:
-            tempchar = decode_baudot(currentUartSymbol);
+            tempchar = decodeBaudot(currentUartSymbol);
             break;
         case 8:  //8-bit ASCII;
             tempchar = currentUartSymbol;
@@ -201,6 +201,7 @@ void uartStyleDecoder::decodeDatabit(int mode)
         default:
             qDebug() << "uartStyleDecoder::decodeDatabit is failing...";
     }
+
     if (parityCheckFailed)
     {
         m_serialBuffer.insert("\n<ERROR: Following character contains parity error>\n");
@@ -209,7 +210,7 @@ void uartStyleDecoder::decodeDatabit(int mode)
     m_serialBuffer.insert(tempchar);
 }
 
-char uartStyleDecoder::decode_baudot([[maybe_unused]] short symbol)
+char uartStyleDecoder::decodeBaudot([[maybe_unused]] short symbol) const
 {
     return 'a';
 }

--- a/Desktop_Interface/uartstyledecoder.cpp
+++ b/Desktop_Interface/uartstyledecoder.cpp
@@ -128,7 +128,6 @@ void uartStyleDecoder::decodeNextUartBit(unsigned char bitValue)
 {
     if (dataBit_current == parityIndex)
     {
-        assert(parity != UartParity::None);
         parityCheckFailed = not isParityCorrect(dataBit_current);
         dataBit_current++;
     }

--- a/Desktop_Interface/uartstyledecoder.h
+++ b/Desktop_Interface/uartstyledecoder.h
@@ -52,7 +52,8 @@ private:
 	std::mutex mutex;
     UartParity parity = UartParity::None;
 
-    void performParityCheck();
+    bool isParityCorrect(uint32_t bitField) const;
+	UartParity parityOf(uint32_t bitField) const;
 
     bool parityCheckFailed = false;
 signals:

--- a/Desktop_Interface/uartstyledecoder.h
+++ b/Desktop_Interface/uartstyledecoder.h
@@ -23,7 +23,7 @@ public:
 	~uartStyleDecoder();
     void serialDecode(double baudRate);
     int serialDistance();
-    QTimer *updateTimer;
+
 private:
     isoBuffer *parent;
     int serialPtr_bit;
@@ -34,17 +34,26 @@ private:
     uint32_t dataBit_max = 7;
     unsigned short currentUartSymbol = 0;
     bool jitterCompensationNeeded = true;
+
     void updateSerialPtr(double baudRate, unsigned char current_bit);
     unsigned char getNextUartBit();
     void decodeNextUartBit(unsigned char bitValue);
     bool jitterCompensationProcedure(double baudRate, unsigned char current_bit);
+
     QPlainTextEdit *console;
     isoBufferBuffer m_serialBuffer;
+public:
+    QTimer m_updateTimer; // IMPORTANT: must be after m_serialBuffer. construction / destruction order matters
+
+private:
     void decodeDatabit(int mode);
     char decode_baudot(short symbol);
+
 	std::mutex mutex;
     UartParity parity = UartParity::None;
+
     void performParityCheck();
+
     bool parityCheckFailed = false;
 signals:
     void wireDisconnected(int);

--- a/Desktop_Interface/uartstyledecoder.h
+++ b/Desktop_Interface/uartstyledecoder.h
@@ -19,14 +19,16 @@ class uartStyleDecoder : public QObject
 {
     Q_OBJECT
 public:
-    explicit uartStyleDecoder(QObject *parent_in = NULL);
-	~uartStyleDecoder();
-    void serialDecode(double baudRate);
-    int serialDistance() const;
+    explicit uartStyleDecoder(double baudRate, QObject *parent = NULL);
+	~uartStyleDecoder() = default;
+
 
 private:
-    isoBuffer *parent;
+    isoBuffer *m_parent;
+
+	// Indicates the current bit being decoded.
     int serialPtr_bit;
+
     bool uartTransmitting = false;
     bool newUartSymbol = false;
     uint32_t dataBit_current = 0;
@@ -35,16 +37,20 @@ private:
     unsigned short currentUartSymbol = 0;
     bool jitterCompensationNeeded = true;
 
-    void updateSerialPtr(double baudRate, unsigned char current_bit);
-    unsigned char getUartBit(int bitIndex) const;
-    void decodeNextUartBit(unsigned char bitValue);
-    bool jitterCompensationProcedure(double baudRate, unsigned char current_bit);
+    void updateSerialPtr(bool current_bit);
+    bool getNextUartBit() const;
+    void decodeNextUartBit(bool bitValue);
+    bool jitterCompensationProcedure(bool current_bit);
 
     QPlainTextEdit *console;
     isoBufferBuffer m_serialBuffer;
 public:
+	double m_baudRate;
     QTimer m_updateTimer; // IMPORTANT: must be after m_serialBuffer. construction / destruction order matters
 
+public:
+    void serialDecode();
+    int serialDistance() const;
 private:
     char decodeDatabit(int mode, short symbol) const;
     char decodeBaudot(short symbol) const;

--- a/Desktop_Interface/uartstyledecoder.h
+++ b/Desktop_Interface/uartstyledecoder.h
@@ -22,7 +22,7 @@ public:
     explicit uartStyleDecoder(QObject *parent_in = NULL);
 	~uartStyleDecoder();
     void serialDecode(double baudRate);
-    int serialDistance();
+    int serialDistance() const;
 
 private:
     isoBuffer *parent;
@@ -36,7 +36,7 @@ private:
     bool jitterCompensationNeeded = true;
 
     void updateSerialPtr(double baudRate, unsigned char current_bit);
-    unsigned char getNextUartBit();
+    unsigned char getNextUartBit() const;
     void decodeNextUartBit(unsigned char bitValue);
     bool jitterCompensationProcedure(double baudRate, unsigned char current_bit);
 
@@ -47,7 +47,7 @@ public:
 
 private:
     void decodeDatabit(int mode);
-    char decode_baudot(short symbol);
+    char decodeBaudot(short symbol) const;
 
 	std::mutex mutex;
     UartParity parity = UartParity::None;

--- a/Desktop_Interface/uartstyledecoder.h
+++ b/Desktop_Interface/uartstyledecoder.h
@@ -39,7 +39,7 @@ private:
     void decodeNextUartBit(unsigned char bitValue);
     bool jitterCompensationProcedure(double baudRate, unsigned char current_bit);
     QPlainTextEdit *console;
-    isoBufferBuffer *serialBuffer;
+    isoBufferBuffer m_serialBuffer;
     void decodeDatabit(int mode);
     char decode_baudot(short symbol);
 	std::mutex mutex;

--- a/Desktop_Interface/uartstyledecoder.h
+++ b/Desktop_Interface/uartstyledecoder.h
@@ -36,7 +36,7 @@ private:
     bool jitterCompensationNeeded = true;
 
     void updateSerialPtr(double baudRate, unsigned char current_bit);
-    unsigned char getNextUartBit() const;
+    unsigned char getUartBit(int bitIndex) const;
     void decodeNextUartBit(unsigned char bitValue);
     bool jitterCompensationProcedure(double baudRate, unsigned char current_bit);
 
@@ -46,7 +46,7 @@ public:
     QTimer m_updateTimer; // IMPORTANT: must be after m_serialBuffer. construction / destruction order matters
 
 private:
-    void decodeDatabit(int mode);
+    char decodeDatabit(int mode, short symbol) const;
     char decodeBaudot(short symbol) const;
 
 	std::mutex mutex;


### PR DESCRIPTION
Hello!

Nothing too crazy on this one. Just a bunch of code transformations that hopefully don't break anything. Biggest thing is definitely making `serialBuffer:isoBufferBuffer` and `updateTimer:QTimer` part of the class instead of pointers (which allowed me to get rid of the body of the destructor). I tried comparing the behavior of some of the methods before and after with some test cases and it seems the same. I might be wrong though, it's 3am and I am having a hard time wrapping my head around the state space of this class.

There will definitely two or three more prs refactoring this class: I'm trying to dial back the size of my prs, which have a tendency to get huge, so I figured I would spread my work over a greater amount of smaller prs. This means some things were left "unfinished" (not really, everything still works but the refactor is less than half done)

The general trend in this pr is making methods act more like functions instead of procedures (i.e. take arguments and return a value instead of using shared state to exchange information). This is something that is still unfinished, a few more of the methods can be made to act more like functions, I just haven't gotten around to it yet.

The style of the code in this file is very different than what i saw on, for instance, isoBuffer. way cleaner, way less duplication, a lot easier to refactor. I wonder if it was written after isoBuffer?

This week is going to be a busy one for me so expect the next pr somewhere around next weekend.