### PR TITLE
I2cdecoder refactor

### DIFF
--- a/Desktop_Interface/i2cdecoder.cpp
+++ b/Desktop_Interface/i2cdecoder.cpp
@@ -86,14 +86,6 @@ void i2cDecoder::runStateMachine()
     edge sdaEdge = edgeDetection(currentSdaValue, previousSdaValue);
 	edge sclEdge = edgeDetection(currentSclValue, previousSclValue);
 
-//    if (sdaEdge == edge::rising || sdaEdge == edge::falling)
-//        qDebug() << "sdaEdge";
-//    if (sclEdge == edge::rising || sclEdge == edge::falling)
-//        qDebug() << "sclEdge";
-
-//    if (sclEdge != edge::held_low)
-//        qDebug() << "sdaEdge" << (uint8_t)sdaEdge << "sclEdge" << (uint8_t)sclEdge;
-
 	if ((sdaEdge == edge::rising) && (sclEdge == edge::falling)) // INVALID STATE TRANSITION
 	{
         state = transmissionState::unknown;

--- a/Desktop_Interface/i2cdecoder.cpp
+++ b/Desktop_Interface/i2cdecoder.cpp
@@ -17,6 +17,13 @@ i2cDecoder::i2cDecoder(isoBuffer* sda_in, isoBuffer* scl_in, QPlainTextEdit* con
             this, &i2cDecoder::updateConsole);
 }
 
+i2cDecoder::~i2cDecoder()
+{
+    // TODO: Is a lock needed here? Destructors should never be called more than once but...
+    delete updateTimer;
+    delete serialBuffer;
+}
+
 void i2cDecoder::reset()
 {
     qDebug () << "Resetting I2C";

--- a/Desktop_Interface/i2cdecoder.cpp
+++ b/Desktop_Interface/i2cdecoder.cpp
@@ -13,8 +13,7 @@ i2cDecoder::i2cDecoder(isoBuffer* sda_in, isoBuffer* scl_in, QPlainTextEdit* con
     updateTimer = new QTimer();
     updateTimer->setTimerType(Qt::PreciseTimer);
     updateTimer->start(CONSOLE_UPDATE_TIMER_PERIOD);
-    connect(updateTimer, &QTimer::timeout,
-            this, &i2cDecoder::updateConsole);
+    connect(updateTimer, &QTimer::timeout, this, &i2cDecoder::updateConsole);
 }
 
 i2cDecoder::~i2cDecoder()

--- a/Desktop_Interface/i2cdecoder.cpp
+++ b/Desktop_Interface/i2cdecoder.cpp
@@ -13,7 +13,8 @@ i2cDecoder::i2cDecoder(isoBuffer* sda_in, isoBuffer* scl_in, QPlainTextEdit* con
     updateTimer = new QTimer();
     updateTimer->setTimerType(Qt::PreciseTimer);
     updateTimer->start(CONSOLE_UPDATE_TIMER_PERIOD);
-    connect(updateTimer, SIGNAL(timeout()), this, SLOT(updateConsole()));
+    connect(updateTimer, &QTimer::timeout,
+            this, &i2cDecoder::updateConsole);
 }
 
 void i2cDecoder::reset()

--- a/Desktop_Interface/i2cdecoder.h
+++ b/Desktop_Interface/i2cdecoder.h
@@ -36,6 +36,7 @@ class i2cDecoder : public QObject
     Q_OBJECT
 public:
     explicit i2cDecoder(isoBuffer* sda_in, isoBuffer* scl_in, QPlainTextEdit* console_in);
+    ~i2cDecoder();
 	// misc
     isoBuffer* sda;
 	isoBuffer* scl;


### PR DESCRIPTION
Code looks pretty darn good around here so there wasn't much to do.

Summary:
 - Constructor new'd up an isoBufferBuffer and a QTimer that were both never freed. I just went for the easy solution and added a destructor. Maybe storing by value or using unique_ptr would be more appropiate?
 - Constructor used SIGNAL and SLOT macros, i replaced that by the type-safe member function pointer overload.
 - Some debug print was left behind, I removed it.

Some things I noticed (but didn't act upon) are:
 - Raw pointers to i2cDecoder::serialBuffer and i2cDecoder::updateTimer (could be store by value or maybe unique_ptr)
 - Everything is public (not really an issue since seemingly no other classes take advantage of this)
 - There is some inconsistent formatting (I didn't want to mess up the blame though so i didn't touch it)

That's all I noticed.

Sebastian.