### PR TITLE
Isodriver refactor - part 1

### DIFF
--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -300,13 +300,13 @@ void isoDriver::setVoltageRange(QWheelEvent *event){
 
         if (event->delta()==120){
             window -= c* ((double)pixPct);
-            delay += c* ((double)100 - (double)pixPct) * pixPct/100;
-            delayUpdated(delay);
+            display.delay += c* ((double)100 - (double)pixPct) * pixPct/100;
+            delayUpdated(display.delay);
         }
         else{
             window += c* ((double)pixPct);
-            delay -= c* ((double)100 - (double)pixPct) * pixPct/100;
-            delayUpdated(delay);
+            display.delay -= c* ((double)100 - (double)pixPct) * pixPct/100;
+            delayUpdated(display.delay);
         }
 
         double mws = fileModeEnabled ? daq_maxWindowSize : ((double)MAX_WINDOW_SIZE);
@@ -316,17 +316,17 @@ void isoDriver::setVoltageRange(QWheelEvent *event){
             window = mws;
             timeWindowUpdated(window);
         }
-        if ((window + delay) > mws)
+        if ((window + display.delay) > mws)
         {
-            delay -= window + delay - mws;
-            delayUpdated(delay);
+            display.delay -= window + display.delay - mws;
+            delayUpdated(display.delay);
         }
-        if (delay < 0)
+        if (display.delay < 0)
         {
-            delay = 0;
-            delayUpdated(delay);
+            display.delay = 0;
+            delayUpdated(display.delay);
         }
-        qDebug() << window << delay;
+        qDebug() << window << display.delay;
     } else {
         qDebug() << "TIGGERED";
         double c = (window) / (double)200;
@@ -345,32 +345,32 @@ void isoDriver::setVoltageRange(QWheelEvent *event){
 
         if (event->delta()==120){
             window -= c* ((double)pixPct);
-            delay += c* ((double)100 - (double)pixPct) * pixPct/100;
-            delayUpdated(delay);
+            display.delay += c* ((double)100 - (double)pixPct) * pixPct/100;
+            delayUpdated(display.delay);
             timeWindowUpdated(window);
         }
         else{
             window += c* ((double)pixPct);
-            delay -= c* ((double)100 - (double)pixPct) * pixPct/100;
-            delayUpdated(delay);
+            display.delay -= c* ((double)100 - (double)pixPct) * pixPct/100;
+            delayUpdated(display.delay);
             timeWindowUpdated(window);
         }
 
         double mws = fileModeEnabled ? daq_maxWindowSize : ((double)MAX_WINDOW_SIZE);
 
         if (window > mws) window = mws;
-        if ((window + delay) > mws)
+        if ((window + display.delay) > mws)
         {
-            delay -= window + delay - mws;
-            delayUpdated(delay);
+            display.delay -= window + display.delay - mws;
+            delayUpdated(display.delay);
         }
-        if (delay < 0)
+        if (display.delay < 0)
         {
-            delay = 0;
-            delayUpdated(delay);
+            display.delay = 0;
+            delayUpdated(display.delay);
         }
         windowAtPause = window;
-        qDebug() << window << delay;
+        qDebug() << window << display.delay;
     }
     //changeTimeAxis(event->delta()==-120);
     //qDebug() << window;
@@ -397,8 +397,8 @@ void isoDriver::pauseEnable_CH1(bool enabled){
     paused_CH1 = enabled;
 
     if(!properlyPaused()) {
-        delay = 0;
-        delayUpdated(delay);
+        display.delay = 0;
+        delayUpdated(display.delay);
         if (autoGainEnabled) autoGain();
         //window = windowAtPause;
     }
@@ -412,8 +412,8 @@ void isoDriver::pauseEnable_CH2(bool enabled){
     paused_CH2 = enabled;
 
     if(!properlyPaused()){
-        delay = 0;
-        delayUpdated(delay);
+        display.delay = 0;
+        delayUpdated(display.delay);
         if (autoGainEnabled) autoGain();
         //window = windowAtPause;
     }
@@ -425,8 +425,8 @@ void isoDriver::pauseEnable_multimeter(bool enabled){
     paused_multimeter = enabled;
 
     if(!properlyPaused()) {
-        delay = 0;
-        delayUpdated(delay);
+        display.delay = 0;
+        delayUpdated(display.delay);
         //window = windowAtPause;
     }
 
@@ -546,13 +546,13 @@ void isoDriver::udateCursors(void){
     vert1y[0] = botRange;
     vert1y[1] = topRange;
 
-    hori0x[0] = -window - delay;
-    hori0x[1] = -delay;
+    hori0x[0] = -window - display.delay;
+    hori0x[1] = -display.delay;
     hori0y[0] = y0;
     hori0y[1] = y0;
 
-    hori1x[0] = -window - delay;
-    hori1x[1] = -delay;
+    hori1x[0] = -window - display.delay;
+    hori1x[1] = -display.delay;
     hori1y[0] = y1;
     hori1y[1] = y1;
 
@@ -697,10 +697,10 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)  //0 for off, 1
     if(singleShotEnabled && (triggerDelay != 0))
         singleShotTriggered(1);
 
-    readData375_CH1 = internalBuffer375_CH1->readBuffer(window,GRAPH_SAMPLES,CH1_mode==2, delay + triggerDelay);
-    if(CH2_mode) readData375_CH2 = internalBuffer375_CH2->readBuffer(window,GRAPH_SAMPLES,CH2_mode==2, delay + triggerDelay);
-    if(CH1_mode == -1) readData750 = internalBuffer750->readBuffer(window,GRAPH_SAMPLES,false, delay + triggerDelay);
-    if(CH1_mode == -2) readDataFile = internalBufferFile->readBuffer(window,GRAPH_SAMPLES,false, delay);
+    readData375_CH1 = internalBuffer375_CH1->readBuffer(window,GRAPH_SAMPLES,CH1_mode==2, display.delay + triggerDelay);
+    if(CH2_mode) readData375_CH2 = internalBuffer375_CH2->readBuffer(window,GRAPH_SAMPLES,CH2_mode==2, display.delay + triggerDelay);
+    if(CH1_mode == -1) readData750 = internalBuffer750->readBuffer(window,GRAPH_SAMPLES,false, display.delay + triggerDelay);
+    if(CH1_mode == -2) readDataFile = internalBufferFile->readBuffer(window,GRAPH_SAMPLES,false, display.delay);
 
     QVector<double> x(GRAPH_SAMPLES), CH1(GRAPH_SAMPLES), CH2(GRAPH_SAMPLES);
 
@@ -744,7 +744,7 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)  //0 for off, 1
 
 
     for (double i=0; i<GRAPH_SAMPLES; i++){
-        x[i] = -(window*i)/((double)(GRAPH_SAMPLES-1)) - delay;
+        x[i] = -(window*i)/((double)(GRAPH_SAMPLES-1)) - display.delay;
         if (x[i]>0) {
             CH1[i] = 0;
             CH2[i] = 0;
@@ -760,7 +760,7 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)  //0 for off, 1
     }else{
         axes->graph(0)->setData(x,CH1);
         if(CH2_mode) axes->graph(1)->setData(x,CH2);
-        axes->xAxis->setRange(-window-delay,-delay);
+        axes->xAxis->setRange(-window-display.delay,-display.delay);
         axes->yAxis->setRange(topRange, botRange);
     }
 
@@ -804,13 +804,13 @@ void isoDriver::multimeterAction(){
     }
 
     double triggerDelay = 0;
-    readData375_CH1 = internalBuffer375_CH1->readBuffer(window,GRAPH_SAMPLES, false, delay + ((triggerEnabled&&!paused_multimeter) ? triggerDelay + window/2 : 0));
+    readData375_CH1 = internalBuffer375_CH1->readBuffer(window,GRAPH_SAMPLES, false, display.delay + ((triggerEnabled&&!paused_multimeter) ? triggerDelay + window/2 : 0));
 
     QVector<double> x(GRAPH_SAMPLES), CH1(GRAPH_SAMPLES);
     analogConvert(readData375_CH1.get(), &CH1, 2048, 0, 1);  //No AC coupling!
 
     for (double i=0; i<GRAPH_SAMPLES; i++){
-        x[i] = -(window*i)/((double)(GRAPH_SAMPLES-1)) - delay;
+        x[i] = -(window*i)/((double)(GRAPH_SAMPLES-1)) - display.delay;
         if (x[i]>0) {
             CH1[i] = 0;
         }
@@ -819,7 +819,7 @@ void isoDriver::multimeterAction(){
 
     udateCursors();
 
-    axes->xAxis->setRange(-window-delay,-delay);
+    axes->xAxis->setRange(-window-display.delay,-display.delay);
     axes->yAxis->setRange(topRange, botRange);
 
     axes->replot();
@@ -1165,8 +1165,8 @@ void isoDriver::setTimeWindow(double newWindow){
 }
 
 void isoDriver::setDelay(double newDelay){
-    delay = newDelay;
-    delayUpdated(delay);
+    display.delay = newDelay;
+    delayUpdated(display.delay);
 }
 
 void isoDriver::takeSnapshot(QString *fileName, unsigned char channel){
@@ -1394,15 +1394,15 @@ void isoDriver::disableFileMode(){
         window = mws;
         timeWindowUpdated(window);
     }
-    if ((window + delay) > mws)
+    if ((window + display.delay) > mws)
     {
-        delay -= window + delay - mws;
-        delayUpdated(delay);
+        display.delay -= window + display.delay - mws;
+        delayUpdated(display.delay);
     }
-    if (delay < 0)
+    if (display.delay < 0)
     {
-        delay = 0;
-        delayUpdated(delay);
+        display.delay = 0;
+        delayUpdated(display.delay);
     }
 }
 

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -210,8 +210,8 @@ void isoDriver::analogConvert(short *shortPtr, QVector<double> *doublePtr, int T
 void isoDriver::digitalConvert(short *shortPtr, QVector<double> *doublePtr){
 
     double *data = doublePtr->data();
-    double top = topRange - (topRange - botRange)/10;
-    double bot = botRange + (topRange - botRange)/10;
+    double top = display.topRange - (display.topRange - display.botRange) / 10;
+    double bot = display.botRange + (display.topRange - display.botRange) / 10;
     for (int i=0;i<GRAPH_SAMPLES;i++){
         data[i] = shortPtr[i] ? top : bot;
     }
@@ -253,7 +253,7 @@ void isoDriver::setVoltageRange(QWheelEvent* event)
     if(doNotTouchGraph && !fileModeEnabled) return;
 
     if (!(event->modifiers() == Qt::ControlModifier)){
-        double c = (topRange - botRange) / (double)400;
+        double c = (display.topRange - display.botRange) / (double)400;
 
         QCPRange range = axes->yAxis->range();
 
@@ -267,19 +267,19 @@ void isoDriver::setVoltageRange(QWheelEvent* event)
         //qDebug() << event->delta();
 
         if (event->delta()==120){
-            topRange -= c* ((double)pixPct);
-            botRange += c* ((double)100 - (double)pixPct);
+            display.topRange -= c * ((double)pixPct);
+            display.botRange += c * ((double)100 - (double)pixPct);
         }
         else{
-            topRange += c* ((double)pixPct);
-            botRange -= c* ((double)100 - (double)pixPct);
+            display.topRange += c * ((double)pixPct);
+            display.botRange -= c * ((double)100 - (double)pixPct);
         }
 
-        if (topRange > (double)20) topRange = (double)20;
-        if (botRange <- (double)20) botRange = (double)-20;
+        if (display.topRange > (double)20) display.topRange = (double)20;
+        if (display.botRange <- (double)20) display.botRange = (double)-20;
         if (autoGainEnabled && !properlyPaused()) autoGain();
-        topRangeUpdated(topRange);
-        botRangeUpdated(botRange);
+        topRangeUpdated(display.topRange);
+        botRangeUpdated(display.botRange);
     }
     else
     {
@@ -413,8 +413,8 @@ void isoDriver::pauseEnable_multimeter(bool enabled){
 
 
 void isoDriver::autoGain(){
-    double maxgain = vcc / (2 * ((double)topRange - vref) * R4/(R3+R4));
-    double mingain = vcc / (2 * ((double)botRange - vref) * R4/(R3+R4));
+    double maxgain = vcc / (2 * ((double)display.topRange - vref) * R4/(R3+R4));
+    double mingain = vcc / (2 * ((double)display.botRange - vref) * R4/(R3+R4));
     maxgain = fmin(fabs(mingain) * 0.98, fabs(maxgain) * 0.98);
 
     double snap[8] = {64, 32, 16, 8, 4, 2, 1, 0.5};
@@ -515,13 +515,13 @@ void isoDriver::udateCursors(void){
 
     vert0x[0] = display.x0;
     vert0x[1] = display.x0;
-    vert0y[0] = botRange;
-    vert0y[1] = topRange;
+    vert0y[0] = display.botRange;
+    vert0y[1] = display.topRange;
 
     vert1x[0] = display.x1;
     vert1x[1] = display.x1;
-    vert1y[0] = botRange;
-    vert1y[1] = topRange;
+    vert1y[0] = display.botRange;
+    vert1y[1] = display.topRange;
 
     hori0x[0] = -display.window - display.delay;
     hori0x[1] = -display.delay;
@@ -737,8 +737,8 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)  //0 for off, 1
     }else{
         axes->graph(0)->setData(x,CH1);
         if(CH2_mode) axes->graph(1)->setData(x,CH2);
-        axes->xAxis->setRange(-display.window-display.delay,-display.delay);
-        axes->yAxis->setRange(topRange, botRange);
+        axes->xAxis->setRange(-display.window - display.delay, -display.delay);
+        axes->yAxis->setRange(display.topRange, display.botRange);
     }
 
     if(snapshotEnabled_CH1){
@@ -796,8 +796,8 @@ void isoDriver::multimeterAction(){
 
     udateCursors();
 
-    axes->xAxis->setRange(-display.window-display.delay,-display.delay);
-    axes->yAxis->setRange(topRange, botRange);
+    axes->xAxis->setRange(-display.window - display.delay, -display.delay);
+    axes->yAxis->setRange(display.topRange, display.botRange);
 
     axes->replot();
     multimeterStats();
@@ -1126,13 +1126,13 @@ void isoDriver::slowTimerTick(){
 }
 
 void isoDriver::setTopRange(double newTop){
-    topRange = newTop;
-    topRangeUpdated(topRange);
+    display.topRange = newTop;
+    topRangeUpdated(display.topRange);
 }
 
 void isoDriver::setBotRange(double newBot){
-    botRange = newBot;
-    botRangeUpdated(botRange);
+    display.botRange = newBot;
+    botRangeUpdated(display.botRange);
 }
 
 void isoDriver::setTimeWindow(double newWindow){

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -25,8 +25,11 @@ class isoBuffer_file;
 // That is one of the things I plan on fixing, and in fact
 // the reason why I began the commenting!
 
-struct DisplayControl
+class DisplayControl : public QObject
 {
+    Q_OBJECT
+public:
+
     double delay = 0;
     double window = 0.01;
     double y0 = 0;
@@ -35,6 +38,14 @@ struct DisplayControl
     double x1 = 0;
     double topRange = 2.5;
     double botRange = -0.5;
+
+    void setVoltageRange (QWheelEvent* event, bool isProperlyPaused, double maxWindowSize, QCustomPlot* axes);
+
+signals:
+    void topRangeUpdated(double);
+    void botRangeUpdated(double);
+    void timeWindowUpdated(double);
+    void delayUpdated(double);
 };
 
 class isoDriver : public QLabel
@@ -83,10 +94,10 @@ private:
     bool paused_CH2 = false;
     bool paused_multimeter = false;
     bool autoGainEnabled = true;
-    bool placingHoriAxes = false;
-    bool placingVertAxes = false;
-    bool horiCursorEnabled = false;
-    bool vertCursorEnabled = false;
+    bool placingHoriAxes = false; // TODO: move into DisplayControl
+    bool placingVertAxes = false; // TODO: move into DisplayControl
+    bool horiCursorEnabled = false; // TODO: move into DisplayControl
+    bool vertCursorEnabled = false; // TODO: move into DisplayControl
     bool triggerEnabled = false;
     bool singleShotEnabled = false;
     bool multimeterShow = true;
@@ -122,7 +133,7 @@ private:
     void frameActionGeneric(char CH1_mode, char CH2_mode);
     void triggerStateChanged();
     //Variables that are just pointers to other classes/vars
-    QCustomPlot *axes;
+    QCustomPlot *axes; // TODO: move into DisplayControl
 	std::unique_ptr<short[]> readData375_CH1;
 	std::unique_ptr<short[]> readData375_CH2;
 	std::unique_ptr<short[]> readData750;

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -15,9 +15,15 @@
 class isoBuffer;
 class isoBuffer_file;
 
-//isoDriver is a huge class.  It handles everything related to the isochronous IN stream - and perhaps that constraint was applied a bit too loosely (spot the C programmer...).
-//Too much stuff is handled in this class, and it's too heavily entangled with the (generic/win/unix)UsbDriver classes.
-//That is one of the things I plan on fixing, and in fact the reason why I began the commenting!
+// isoDriver is a huge class.  It handles everything related to the
+// isochronous IN stream - and perhaps that constraint was applied
+// a bit too loosely (spot the C programmer...).
+
+// Too much stuff is handled in this class, and it's too heavily
+// entangled with the (generic/win/unix)UsbDriver classes.
+
+// That is one of the things I plan on fixing, and in fact
+// the reason why I began the commenting!
 
 class isoDriver : public QLabel
 {
@@ -26,26 +32,37 @@ public:
     explicit isoDriver(QWidget *parent = 0);
     void autoGain(void);
     //Generic Vars
-    isoBuffer *internalBuffer375_CH1, *internalBuffer375_CH2, *internalBuffer750;
+    isoBuffer *internalBuffer375_CH1;
+    isoBuffer *internalBuffer375_CH2;
+    isoBuffer *internalBuffer750;
     isoBuffer_file *internalBufferFile = NULL;
 #if QCP_VER == 1
     QCPItemText *cursorTextPtr;
 #endif
     genericUsbDriver *driver;
     bool doNotTouchGraph = true;
-    double ch1_ref = 1.65, ch2_ref = 1.65;
-    double frontendGain_CH1 = (R4/(R3+R4)), frontendGain_CH2 = (R4/(R3+R4));
+    double ch1_ref = 1.65;
+    double ch2_ref = 1.65;
+    double frontendGain_CH1 = (R4/(R3+R4));
+    double frontendGain_CH2 = (R4/(R3+R4));
     UartParity parity_CH1 = UartParity::None;
     UartParity parity_CH2 = UartParity::None;
     //State Vars
-    bool AC_CH1 = false, AC_CH2 = false;
+    bool AC_CH1 = false;
+    bool AC_CH2 = false;
     bool cursorStatsEnabled = true;
-    int baudRate_CH1 = 9600, baudRate_CH2 = 9600;
+    int baudRate_CH1 = 9600;
+    int baudRate_CH2 = 9600;
     double currentVmean;
     //Display Control Vars     (Variables that control how the buffers are displayed)
-    double delay = 0, window = 0.01;
-    double y0=0, y1=0, x0=0, x1=0;
-    double topRange=2.5, botRange=-0.5;
+    double delay = 0;
+    double window = 0.01;
+    double y0=0;
+    double y1=0;
+    double x0=0;
+    double x1=0;
+    double topRange=2.5;
+    double botRange=-0.5;
     //Generic Functions
     void setDriver(genericUsbDriver *newDriver);
     void setAxes(QCustomPlot *newAxes);
@@ -57,9 +74,14 @@ public:
     double daq_maxWindowSize;
 private:
     //Those bloody bools that just Enable/Disable a single property
-    bool paused_CH1 = false, paused_CH2 = false, paused_multimeter = false;
+    bool paused_CH1 = false;
+    bool paused_CH2 = false;
+    bool paused_multimeter = false;
     bool autoGainEnabled = true;
-    bool placingHoriAxes = false, placingVertAxes = false, horiCursorEnabled = false, vertCursorEnabled = false;
+    bool placingHoriAxes = false;
+    bool placingVertAxes = false;
+    bool horiCursorEnabled = false;
+    bool vertCursorEnabled = false;
     bool triggerEnabled = false;
     bool singleShotEnabled = false;
     bool multimeterShow = true;
@@ -75,9 +97,11 @@ private:
     bool forceAmps = false;
     bool forceOhms = false;
     bool forceNFarads = false;
-    bool serialDecodeEnabled_CH1 = false, serialDecodeEnabled_CH2 = false;
+    bool serialDecodeEnabled_CH1 = false;
+    bool serialDecodeEnabled_CH2 = false;
     bool XYmode = false;
-    bool update_CH1 = true, update_CH2 = true;
+    bool update_CH1 = true;
+    bool update_CH2 = true;
     bool snapshotEnabled_CH1 = false;
     bool snapshotEnabled_CH2 = false;
     bool firstFrame = true;
@@ -100,11 +124,22 @@ private:
     float *readDataFile;
     char *isoTemp = NULL;
     short *isoTemp_short = NULL;
-    siprint *v0, *v1, *dv, *t0, *t1, *dt, *f;
+    siprint *v0;
+    siprint *v1;
+    siprint *dv;
+    siprint *t0;
+    siprint *t1;
+    siprint *dt;
+    siprint *f;
     //Scope/MM++ related variables
-    double currentVmax, currentVmin, currentVRMS;
+    double currentVmax;
+    double currentVmin;
+    double currentVRMS;
     double multi = 0;
-    double xmin = 20, xmax = -20, ymin = 20, ymax = -20;
+    double xmin = 20;
+    double xmax = -20;
+    double ymin = 20;
+    double ymax = -20;
     double estimated_resistance = 0;
     int multimeterRsource = 0;
     int triggerMode = 0;
@@ -122,7 +157,9 @@ private:
     bool twoWireStateInvalid = true;
     //Generic Vars
     double windowAtPause = 0.01;
-    QTimer* isoTimer = NULL, *slowTimer = NULL, *fileTimer = NULL;
+    QTimer* isoTimer = NULL;
+    QTimer *slowTimer = NULL;
+    QTimer *fileTimer = NULL;
     long total_read = 0;
     unsigned int length;
     QFile *snapshotFile_CH1;

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -29,6 +29,10 @@ struct DisplayControl
 {
     double delay = 0;
     double window = 0.01;
+    double y0 = 0;
+    double y1 = 0;
+    double x0 = 0;
+    double x1 = 0;
 };
 
 class isoDriver : public QLabel
@@ -62,10 +66,6 @@ public:
     double currentVmean;
     //Display Control Vars (Variables that control how the buffers are displayed)
     DisplayControl display;
-    double y0=0;
-    double y1=0;
-    double x0=0;
-    double x1=0;
     double topRange=2.5;
     double botRange=-0.5;
     //Generic Functions

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -28,6 +28,7 @@ class isoBuffer_file;
 struct DisplayControl
 {
     double delay = 0;
+    double window = 0.01;
 };
 
 class isoDriver : public QLabel
@@ -61,7 +62,6 @@ public:
     double currentVmean;
     //Display Control Vars (Variables that control how the buffers are displayed)
     DisplayControl display;
-    double window = 0.01;
     double y0=0;
     double y1=0;
     double x0=0;
@@ -161,7 +161,6 @@ private:
     i2c::i2cDecoder* twoWire = nullptr;
     bool twoWireStateInvalid = true;
     //Generic Vars
-    double windowAtPause = 0.01;
     QTimer* isoTimer = NULL;
     QTimer *slowTimer = NULL;
     QTimer *fileTimer = NULL;
@@ -205,7 +204,6 @@ signals:
     void timeWindowUpdated(double);
     void delayUpdated(double);
 public slots:
-    void setWindow(int newWindow);
     void setVoltageRange(QWheelEvent *event);
     void timerTick(void);
     void pauseEnable_CH1(bool enabled);

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -25,6 +25,11 @@ class isoBuffer_file;
 // That is one of the things I plan on fixing, and in fact
 // the reason why I began the commenting!
 
+struct DisplayControl
+{
+    double delay = 0;
+};
+
 class isoDriver : public QLabel
 {
     Q_OBJECT
@@ -54,8 +59,8 @@ public:
     int baudRate_CH1 = 9600;
     int baudRate_CH2 = 9600;
     double currentVmean;
-    //Display Control Vars     (Variables that control how the buffers are displayed)
-    double delay = 0;
+    //Display Control Vars (Variables that control how the buffers are displayed)
+    DisplayControl display;
     double window = 0.01;
     double y0=0;
     double y1=0;

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -33,6 +33,8 @@ struct DisplayControl
     double y1 = 0;
     double x0 = 0;
     double x1 = 0;
+    double topRange = 2.5;
+    double botRange = -0.5;
 };
 
 class isoDriver : public QLabel
@@ -66,8 +68,6 @@ public:
     double currentVmean;
     //Display Control Vars (Variables that control how the buffers are displayed)
     DisplayControl display;
-    double topRange=2.5;
-    double botRange=-0.5;
     //Generic Functions
     void setDriver(genericUsbDriver *newDriver);
     void setAxes(QCustomPlot *newAxes);

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -4,6 +4,8 @@
 #include <QDesktopServices>
 #include "espospinbox.h"
 
+#include <algorithm>
+
 #define DO_QUOTE(X) #X
 #define QUOTE(X) DO_QUOTE(X)
 
@@ -1184,8 +1186,8 @@ void MainWindow::on_actionSnap_to_Cursors_triggered()
     xLeft = std::min(ui->controller_iso->display.x1, ui->controller_iso->display.x0);
 
     if((yBot-yTop) != 0){
-        ui->controller_iso->topRange = yTop;
-        ui->controller_iso->botRange = yBot;
+        ui->controller_iso->display.topRange = yTop;
+        ui->controller_iso->display.botRange = yBot;
     }
 
     if((xLeft - xRight) != 0){
@@ -1197,7 +1199,7 @@ void MainWindow::on_actionSnap_to_Cursors_triggered()
 void MainWindow::on_actionEnter_Manually_triggered()
 {
     ui->controller_iso->display.delay = 0;
-    scopeRangeEnterDialog dialog(this, ui->controller_iso->topRange, ui->controller_iso->botRange, ui->controller_iso->display.window, ui->controller_iso->display.delay);
+    scopeRangeEnterDialog dialog(this, ui->controller_iso->display.topRange, ui->controller_iso->display.botRange, ui->controller_iso->display.window, ui->controller_iso->display.delay);
     dialog.setModal(true);
     connect(&dialog, SIGNAL(yTopUpdated(double)), ui->controller_iso, SLOT(setTopRange(double)));
     connect(&dialog, SIGNAL(yBotUpdated(double)), ui->controller_iso, SLOT(setBotRange(double)));
@@ -2300,7 +2302,7 @@ void MainWindow::on_actionShow_Range_Dialog_on_Main_Page_triggered(bool checked)
     qDebug() << "on_actionShow_Range_Dialog_on_Main_Page_triggered" << checked;
     if (checked)
     {
-        scopeRangeSwitch = new scopeRangeEnterDialog(nullptr, false, ui->controller_iso->topRange, ui->controller_iso->botRange, ui->controller_iso->display.window, ui->controller_iso->display.delay);
+        scopeRangeSwitch = new scopeRangeEnterDialog(nullptr, false, ui->controller_iso->display.topRange, ui->controller_iso->display.botRange, ui->controller_iso->display.window, ui->controller_iso->display.delay);
         scopeRangeSwitch->setWindowFlags(Qt::Widget);
         ui->verticalLayout_5->insertWidget(2, scopeRangeSwitch);
         connect(scopeRangeSwitch, SIGNAL(yTopUpdated(double)), ui->controller_iso, SLOT(setTopRange(double)));

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -1072,7 +1072,7 @@ void MainWindow::ctrlArrowDownTriggered(){
 
 void MainWindow::cycleDelayRight(){
     qDebug() << "RIGHT";
-    ui->controller_iso->display.delay -= ui->controller_iso->window/10;
+    ui->controller_iso->display.delay -= ui->controller_iso->display.window/10;
     if(ui->controller_iso->display.delay < 0) ui->controller_iso->display.delay = 0;
     ui->controller_iso->delayUpdated(ui->controller_iso->display.delay);
 }
@@ -1080,14 +1080,14 @@ void MainWindow::cycleDelayRight(){
 void MainWindow::cycleDelayLeft(){
     qDebug() << "LEFT";
     double mws = ui->controller_iso->fileModeEnabled ? ui->controller_iso->daq_maxWindowSize : ((double)MAX_WINDOW_SIZE);
-    ui->controller_iso->display.delay += ui->controller_iso->window/10;
-    if(ui->controller_iso->display.delay > (mws - ui->controller_iso->window)) ui->controller_iso->display.delay = (mws - ui->controller_iso->window);
+    ui->controller_iso->display.delay += ui->controller_iso->display.window/10;
+    if(ui->controller_iso->display.delay > (mws - ui->controller_iso->display.window)) ui->controller_iso->display.delay = (mws - ui->controller_iso->display.window);
     ui->controller_iso->delayUpdated(ui->controller_iso->display.delay);
 }
 
 void MainWindow::cycleDelayRight_large(){
     qDebug() << "RIGHT";
-    ui->controller_iso->display.delay -= ui->controller_iso->window/2;
+    ui->controller_iso->display.delay -= ui->controller_iso->display.window/2;
     if(ui->controller_iso->display.delay < 0) ui->controller_iso->display.delay = 0;
     ui->controller_iso->delayUpdated(ui->controller_iso->display.delay);
 }
@@ -1095,8 +1095,8 @@ void MainWindow::cycleDelayRight_large(){
 void MainWindow::cycleDelayLeft_large(){
     qDebug() << "LEFT";
     double mws = ui->controller_iso->fileModeEnabled ? ui->controller_iso->daq_maxWindowSize : ((double)MAX_WINDOW_SIZE);
-    ui->controller_iso->display.delay += ui->controller_iso->window/2;
-    if(ui->controller_iso->display.delay > (mws - ui->controller_iso->window)) ui->controller_iso->display.delay = (mws - ui->controller_iso->window);
+    ui->controller_iso->display.delay += ui->controller_iso->display.window/2;
+    if(ui->controller_iso->display.delay > (mws - ui->controller_iso->display.window)) ui->controller_iso->display.delay = (mws - ui->controller_iso->display.window);
     ui->controller_iso->delayUpdated(ui->controller_iso->display.delay);
 }
 
@@ -1190,14 +1190,14 @@ void MainWindow::on_actionSnap_to_Cursors_triggered()
 
     if((xLeft - xRight) != 0){
         ui->controller_iso->display.delay = - xRight;
-        ui->controller_iso->window = xRight - xLeft;
+        ui->controller_iso->display.window = xRight - xLeft;
     }
 }
 
 void MainWindow::on_actionEnter_Manually_triggered()
 {
     ui->controller_iso->display.delay = 0;
-    scopeRangeEnterDialog dialog(this, ui->controller_iso->topRange, ui->controller_iso->botRange, ui->controller_iso->window, ui->controller_iso->display.delay);
+    scopeRangeEnterDialog dialog(this, ui->controller_iso->topRange, ui->controller_iso->botRange, ui->controller_iso->display.window, ui->controller_iso->display.delay);
     dialog.setModal(true);
     connect(&dialog, SIGNAL(yTopUpdated(double)), ui->controller_iso, SLOT(setTopRange(double)));
     connect(&dialog, SIGNAL(yBotUpdated(double)), ui->controller_iso, SLOT(setBotRange(double)));
@@ -2300,7 +2300,7 @@ void MainWindow::on_actionShow_Range_Dialog_on_Main_Page_triggered(bool checked)
     qDebug() << "on_actionShow_Range_Dialog_on_Main_Page_triggered" << checked;
     if (checked)
     {
-        scopeRangeSwitch = new scopeRangeEnterDialog(nullptr, false, ui->controller_iso->topRange, ui->controller_iso->botRange, ui->controller_iso->window, ui->controller_iso->display.delay);
+        scopeRangeSwitch = new scopeRangeEnterDialog(nullptr, false, ui->controller_iso->topRange, ui->controller_iso->botRange, ui->controller_iso->display.window, ui->controller_iso->display.delay);
         scopeRangeSwitch->setWindowFlags(Qt::Widget);
         ui->verticalLayout_5->insertWidget(2, scopeRangeSwitch);
         connect(scopeRangeSwitch, SIGNAL(yTopUpdated(double)), ui->controller_iso, SLOT(setTopRange(double)));

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -1177,11 +1177,11 @@ void MainWindow::on_actionSnap_to_Cursors_triggered()
 {
     double xLeft, xRight, yBot, yTop;
 
-    yTop = ui->controller_iso->y1 > ui->controller_iso->y0 ? ui->controller_iso->y1 : ui->controller_iso->y0;
-    yBot = ui->controller_iso->y1 > ui->controller_iso->y0 ? ui->controller_iso->y0 : ui->controller_iso->y1;
+    yTop = std::max(ui->controller_iso->display.y1, ui->controller_iso->display.y0);
+    yBot = std::min(ui->controller_iso->display.y1, ui->controller_iso->display.y0);
 
-    xRight = ui->controller_iso->x1 > ui->controller_iso->x0 ? ui->controller_iso->x1 : ui->controller_iso->x0;
-    xLeft = ui->controller_iso->x1 > ui->controller_iso->x0 ? ui->controller_iso->x0 : ui->controller_iso->x1;
+    xRight = std::max(ui->controller_iso->display.x1, ui->controller_iso->display.x0);
+    xLeft = std::min(ui->controller_iso->display.x1, ui->controller_iso->display.x0);
 
     if((yBot-yTop) != 0){
         ui->controller_iso->topRange = yTop;

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -1072,32 +1072,32 @@ void MainWindow::ctrlArrowDownTriggered(){
 
 void MainWindow::cycleDelayRight(){
     qDebug() << "RIGHT";
-    ui->controller_iso->delay -= ui->controller_iso->window/10;
-    if(ui->controller_iso->delay < 0) ui->controller_iso->delay = 0;
-    ui->controller_iso->delayUpdated(ui->controller_iso->delay);
+    ui->controller_iso->display.delay -= ui->controller_iso->window/10;
+    if(ui->controller_iso->display.delay < 0) ui->controller_iso->display.delay = 0;
+    ui->controller_iso->delayUpdated(ui->controller_iso->display.delay);
 }
 
 void MainWindow::cycleDelayLeft(){
     qDebug() << "LEFT";
     double mws = ui->controller_iso->fileModeEnabled ? ui->controller_iso->daq_maxWindowSize : ((double)MAX_WINDOW_SIZE);
-    ui->controller_iso->delay += ui->controller_iso->window/10;
-    if(ui->controller_iso->delay > (mws - ui->controller_iso->window)) ui->controller_iso->delay = (mws - ui->controller_iso->window);
-    ui->controller_iso->delayUpdated(ui->controller_iso->delay);
+    ui->controller_iso->display.delay += ui->controller_iso->window/10;
+    if(ui->controller_iso->display.delay > (mws - ui->controller_iso->window)) ui->controller_iso->display.delay = (mws - ui->controller_iso->window);
+    ui->controller_iso->delayUpdated(ui->controller_iso->display.delay);
 }
 
 void MainWindow::cycleDelayRight_large(){
     qDebug() << "RIGHT";
-    ui->controller_iso->delay -= ui->controller_iso->window/2;
-    if(ui->controller_iso->delay < 0) ui->controller_iso->delay = 0;
-    ui->controller_iso->delayUpdated(ui->controller_iso->delay);
+    ui->controller_iso->display.delay -= ui->controller_iso->window/2;
+    if(ui->controller_iso->display.delay < 0) ui->controller_iso->display.delay = 0;
+    ui->controller_iso->delayUpdated(ui->controller_iso->display.delay);
 }
 
 void MainWindow::cycleDelayLeft_large(){
     qDebug() << "LEFT";
     double mws = ui->controller_iso->fileModeEnabled ? ui->controller_iso->daq_maxWindowSize : ((double)MAX_WINDOW_SIZE);
-    ui->controller_iso->delay += ui->controller_iso->window/2;
-    if(ui->controller_iso->delay > (mws - ui->controller_iso->window)) ui->controller_iso->delay = (mws - ui->controller_iso->window);
-    ui->controller_iso->delayUpdated(ui->controller_iso->delay);
+    ui->controller_iso->display.delay += ui->controller_iso->window/2;
+    if(ui->controller_iso->display.delay > (mws - ui->controller_iso->window)) ui->controller_iso->display.delay = (mws - ui->controller_iso->window);
+    ui->controller_iso->delayUpdated(ui->controller_iso->display.delay);
 }
 
 void MainWindow::enableLabradorDebugging(){
@@ -1189,15 +1189,15 @@ void MainWindow::on_actionSnap_to_Cursors_triggered()
     }
 
     if((xLeft - xRight) != 0){
-        ui->controller_iso->delay = - xRight;
+        ui->controller_iso->display.delay = - xRight;
         ui->controller_iso->window = xRight - xLeft;
     }
 }
 
 void MainWindow::on_actionEnter_Manually_triggered()
 {
-    ui->controller_iso->delay = 0;
-    scopeRangeEnterDialog dialog(this, ui->controller_iso->topRange, ui->controller_iso->botRange, ui->controller_iso->window, ui->controller_iso->delay);
+    ui->controller_iso->display.delay = 0;
+    scopeRangeEnterDialog dialog(this, ui->controller_iso->topRange, ui->controller_iso->botRange, ui->controller_iso->window, ui->controller_iso->display.delay);
     dialog.setModal(true);
     connect(&dialog, SIGNAL(yTopUpdated(double)), ui->controller_iso, SLOT(setTopRange(double)));
     connect(&dialog, SIGNAL(yBotUpdated(double)), ui->controller_iso, SLOT(setBotRange(double)));
@@ -2300,7 +2300,7 @@ void MainWindow::on_actionShow_Range_Dialog_on_Main_Page_triggered(bool checked)
     qDebug() << "on_actionShow_Range_Dialog_on_Main_Page_triggered" << checked;
     if (checked)
     {
-        scopeRangeSwitch = new scopeRangeEnterDialog(nullptr, false, ui->controller_iso->topRange, ui->controller_iso->botRange, ui->controller_iso->window, ui->controller_iso->delay);
+        scopeRangeSwitch = new scopeRangeEnterDialog(nullptr, false, ui->controller_iso->topRange, ui->controller_iso->botRange, ui->controller_iso->window, ui->controller_iso->display.delay);
         scopeRangeSwitch->setWindowFlags(Qt::Widget);
         ui->verticalLayout_5->insertWidget(2, scopeRangeSwitch);
         connect(scopeRangeSwitch, SIGNAL(yTopUpdated(double)), ui->controller_iso, SLOT(setTopRange(double)));


### PR DESCRIPTION
In this PR, I started moving everything that's related to graphing in isoDriver into its own class, DisplayControl (working name).

For the sake of reasonable PR sizes I am doing it now, even though it's mostly incomplete. There are still a bunch of variables (marked with a TODO comment) that I want to move over, as well as a bunch of methods. Right now I'm passing a whole bunch of things around to make everything work "as before".

The quotation marks around "as before" are there because it's not really working quite like it used to: `updateTimeWindow` is called even if the display is `properlyPaused()`. Before, this was not so. I assumed this was a mistake since i saw no reason not to call it.

Code is pretty messy right now but it should settle down once I'm done with the changes I intend on doing probably by next PR.

I also did slip a few cheeky purely formatting-based changes in, just to make old code fit the style of the more recent code. I tried to make sure that I only give this treatment to code that was going to show up in the diff anyways, as to not pollute the blame.

Speaking of formatting, I've been using clang-format to do these formatting changes automatically. For that purpose, I wrote a really barebones .clang-format file which I think fits the style guidelines you described to me sometime in the past (can't remember if it was on an email or a PR comment) and was wondering if you would be interested in me adding a PR for that?

Alright. it's pretty late and I feel like my writing is all over the place, so I'm gonna wrap this up by asking what's up with all the redundant type casts? Not that it bothers me, I was just wondering...

Anyways, it's nice to be back, warm regards,

Sebastian