### PR TITLE
Enable smooth zoom

### DIFF
--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -264,10 +264,7 @@ void isoDriver::setVoltageRange(QWheelEvent* event)
 
 void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused, double maxWindowSize, QCustomPlot* axes)
 {
-    if (event->orientation() == Qt::Orientation::Horizontal)
-        return;
-
-    if (!(event->modifiers() == Qt::ControlModifier)){
+    if (!(event->modifiers() == Qt::ControlModifier) && event->orientation() == Qt::Orientation::Vertical) {
         double c = (topRange - botRange) / (double)400;
 
         QCPRange range = axes->yAxis->range();
@@ -276,11 +273,11 @@ void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused,
         if (pixPct < 0) pixPct = 0; 
         if (pixPct > 100) pixPct = 100;
 
-        qDebug() << "WHEEL @ " << pixPct << "%, delta=" << event->delta() << ", orientation=" << event->orientation();
+        qDebug() << "WHEEL @ " << pixPct << "%";
         qDebug() << range.upper;
 
-        topRange -= (event->delta() / 120.0) * c * pixPct;
-        botRange += (event->delta() / 120.0) * c * pixPct;
+        topRange -= event->delta() / 120.0 * c * pixPct;
+        botRange += event->delta() / 120.0 * c * (100.0 - pixPct);
 
         if (topRange > (double)20) topRange = (double)20;
         if (botRange < -(double)20) botRange = (double)-20;
@@ -315,8 +312,8 @@ void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused,
             qDebug() << c * ((double)100 - (double)pixPct) * pixPct / 100;
         }
 
-        window -= event->delta() / 120.0 * c * ((double)pixPct);
-        delay += event->delta() / 120.0 * c * ((double)100 - (double)pixPct) * pixPct / 100;
+        window -= event->delta() / 120.0 * c * pixPct;
+        delay += event->delta() / 120.0 * c * (100.0 - pixPct) * pixPct / 100.0;
 
         // NOTE: delayUpdated and timeWindowUpdated are called more than once beyond here,
         // maybe they should only be called once at the end?

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -264,6 +264,9 @@ void isoDriver::setVoltageRange(QWheelEvent* event)
 
 void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused, double maxWindowSize, QCustomPlot* axes)
 {
+    if (event->orientation() == Qt::Orientation::Horizontal)
+        return;
+
     if (!(event->modifiers() == Qt::ControlModifier)){
         double c = (topRange - botRange) / (double)400;
 
@@ -273,17 +276,11 @@ void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused,
         if (pixPct < 0) pixPct = 0; 
         if (pixPct > 100) pixPct = 100;
 
-        qDebug() << "WHEEL @ " << pixPct << "%";
+        qDebug() << "WHEEL @ " << pixPct << "%, delta=" << event->delta() << ", orientation=" << event->orientation();
         qDebug() << range.upper;
 
-        if (event->delta()==120){
-            topRange -= c * ((double)pixPct);
-            botRange += c * ((double)100 - (double)pixPct);
-        }
-        else{
-            topRange += c * ((double)pixPct);
-            botRange -= c * ((double)100 - (double)pixPct);
-        }
+        topRange -= (event->delta() / 120.0) * c * pixPct;
+        botRange += (event->delta() / 120.0) * c * pixPct;
 
         if (topRange > (double)20) topRange = (double)20;
         if (botRange < -(double)20) botRange = (double)-20;
@@ -318,16 +315,8 @@ void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused,
             qDebug() << c * ((double)100 - (double)pixPct) * pixPct / 100;
         }
 
-        if (event->delta() == 120)
-        {
-            window -= c * ((double)pixPct);
-            delay += c * ((double)100 - (double)pixPct) * pixPct / 100;
-        }
-        else
-        {
-            window += c * ((double)pixPct);
-            delay -= c * ((double)100 - (double)pixPct) * pixPct / 100;
-        }
+        window -= event->delta() / 120.0 * c * ((double)pixPct);
+        delay += event->delta() / 120.0 * c * ((double)100 - (double)pixPct) * pixPct / 100;
 
         // NOTE: delayUpdated and timeWindowUpdated are called more than once beyond here,
         // maybe they should only be called once at the end?


### PR DESCRIPTION
The current code interprets wheel events with a scroll distance of 120 units as a zoom in one direction, and all other wheel events as a zoom in the other direction. When a mac touchpad sends many high-resolution events of less than 120 units, the result is that you instantly get zoomed all the way out with no way to zoom back in.

This PR fixes that: trackpad scroll gestures, in both the horizontal and vertical directions, smoothly zoom the time and voltage axes.