### PR TITLE
Allow PSU abort from PSU calibration

### DIFF
--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -2203,6 +2203,13 @@ void MainWindow::on_actionCalibrate_2_triggered()
 {
     qDebug() << "Calibrating PSU!";
 
+    if (!ui->controller_iso->driver->connected) {
+        calibrationMessages->setStandardButtons(QMessageBox::Ok);
+        calibrationMessages->setText("You need to connect the board before calibrating it!");
+        calibrationMessages->exec();
+        return;
+    }
+
     //Abort if Scope is uncalibrated
     if ((ui->controller_iso->ch1_ref == 1.65) && (ui->controller_iso->ch2_ref == 1.65) && (ui->controller_iso->frontendGain_CH1 ==  R4/(R3+R4)) && (ui->controller_iso->frontendGain_CH2 == R4/(R3+R4)))\
     {
@@ -2212,9 +2219,11 @@ void MainWindow::on_actionCalibrate_2_triggered()
         return;
     }
 
-    calibrationMessages->setStandardButtons(QMessageBox::Ok);
+    calibrationMessages->setStandardButtons(QMessageBox::Ok|QMessageBox::Cancel);
     calibrationMessages->setText("Power Supply calibration requires me to control your power supply temporarily.  \n\nTO PREVENT BLUE SMOKE DAMAGE, DISCONNECT ANY CIRCUIT ATTACHED TO YOUR POWER SUPPLY NOW.");
-    calibrationMessages->exec();
+    if (calibrationMessages->exec() == QMessageBox::Cancel) {
+	return;
+    }
 
     qDebug() << "Beginning PSU calibration!";
 

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -2222,7 +2222,7 @@ void MainWindow::on_actionCalibrate_2_triggered()
     calibrationMessages->setStandardButtons(QMessageBox::Ok|QMessageBox::Cancel);
     calibrationMessages->setText("Power Supply calibration requires me to control your power supply temporarily.  \n\nTO PREVENT BLUE SMOKE DAMAGE, DISCONNECT ANY CIRCUIT ATTACHED TO YOUR POWER SUPPLY NOW.");
     if (calibrationMessages->exec() == QMessageBox::Cancel) {
-	return;
+        return;
     }
 
     qDebug() << "Beginning PSU calibration!";


### PR DESCRIPTION
Hi Chris,

This fixes a couple of minor nits with the calibration UI:

1) If "Calibrate" is chosen from the "Oscilloscope" menu, then there is a check if USB is connected, and calibration doesn't proceed if not connected.  However if "Calibrate" is chosen from the "Power Supply" menu, there is no such check.  An equivalent check is added for UI consistency.

2) After oscilloscope calibration is done, the UI flow goes straight into PSU calibration, whether or not the user wants to do that.  This adds a "Cancel" button to the PSU calibration dialog to allow PSU calibration to be skipped after oscilloscope calibration is complete.

Thanks,

John