### PR TITLE
Exporting the current oscilloscope view as image

### DIFF
--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -1966,6 +1966,47 @@ void MainWindow::openFileDialog(QString *fileName){
     *(fileName) = temp;
 }
 
+void MainWindow::on_actionExportImage_triggered()
+{
+    qDebug() << "on_actionExportImage_triggered()";
+
+    QFileDialog dialog;
+
+    dialog.setDefaultSuffix("pdf");
+    dialog.setAcceptMode(QFileDialog::AcceptSave);
+    dialog.setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
+    dialog.setFileMode(QFileDialog::AnyFile);
+    dialog.setNameFilter("PDF files (*.pdf);;JPEG files (*.jpg);;PNG files (*.png);;BMP files (*.bmp)");
+
+    int retVal = dialog.exec();
+
+    if(!retVal){
+        return; //User did not select a file!
+    }
+
+    QStringList tempList = dialog.selectedFiles();
+    qDebug() << tempList.first();
+
+    // Avoiding an if () cascade
+    switch (dialog.nameFilters().indexOf( dialog.selectedNameFilter() ) )
+    {
+        case 0:
+            ui->scopeAxes->savePdf(tempList.first());
+            break;
+        case 1:
+            ui->scopeAxes->saveJpg(tempList.first());
+            break;
+        case 2:
+            ui->scopeAxes->savePng(tempList.first());
+            break;
+        case 3:
+            ui->scopeAxes->saveBmp(tempList.first());
+            break;
+        default:
+            qDebug() << "Wrong file type for exporting image to";
+    }
+}
+
 void MainWindow::on_actionSnapshot_CH1_triggered()
 {
   qDebug() << "on_actionSnapshot_CH1_triggered()";

--- a/Desktop_Interface/mainwindow.h
+++ b/Desktop_Interface/mainwindow.h
@@ -150,6 +150,8 @@ private slots:
 
     void on_actionSingle_ep_async_triggered();
 
+    void on_actionExportImage_triggered();
+
     void on_actionSnapshot_CH1_triggered();
 
     void on_actionSnapshot_CH2_triggered();

--- a/Desktop_Interface/ui_files_desktop/mainwindow.ui
+++ b/Desktop_Interface/ui_files_desktop/mainwindow.ui
@@ -1532,6 +1532,7 @@
     <addaction name="menuRecord"/>
     <addaction name="actionOpen_DAQ_File"/>
     <addaction name="menuTake_Snapshot"/>
+    <addaction name="actionExportImage"/>
     <addaction name="actionQuit"/>
    </widget>
    <widget class="QMenu" name="menuOscilloscope_2">
@@ -2420,6 +2421,11 @@
    </property>
    <property name="text">
     <string>single-&amp;ep-async</string>
+   </property>
+  </action>
+  <action name="actionExportImage">
+   <property name="text">
+    <string>&amp;Export current view</string>
    </property>
   </action>
   <action name="actionSnapshot_CH1">


### PR DESCRIPTION
Hello. Got a quick PR for you, not sure if the code is optimal but would be nice if you had a look.

This adds an "Export Current view" option to the file menu, which captures the current scope view as an image, using the current window dimensions for the picture size.

The primary motivation was to be able to take vector (PDF, but still) screenshots.

[out.pdf](https://github.com/EspoTek/Labrador/files/6175781/out.pdf)
