### PR TITLE
Don't strip all optimization flags.

### DIFF
--- a/Desktop_Interface/Labrador.pro
+++ b/Desktop_Interface/Labrador.pro
@@ -251,29 +251,6 @@ unix:SOURCES += unixusbdriver.cpp
 unix:HEADERS += unixusbdriver.h
 
 #############################################################
-########       SHARED ANDROID/LINUX GCC FLAGS      #########
-###########################################################
-
-unix:!macx: QMAKE_CXXFLAGS_RELEASE -= -O0
-unix:!macx: QMAKE_CXXFLAGS_RELEASE -= -O1
-unix:!macx: QMAKE_CXXFLAGS_RELEASE -= -O2
-unix:!macx: QMAKE_CXXFLAGS_RELEASE -= -O3
-
-android: QMAKE_CXXFLAGS_RELEASE -= -O0
-android: QMAKE_CXXFLAGS_RELEASE -= -O1
-android: QMAKE_CXXFLAGS_RELEASE -= -O2
-android: QMAKE_CXXFLAGS_RELEASE -= -O3
-android: QMAKE_CXXFLAGS_RELEASE -= -Os
-
-
-android: QMAKE_CFLAGS_RELEASE -= -O0
-android: QMAKE_CFLAGS_RELEASE -= -O1
-android: QMAKE_CFLAGS_RELEASE -= -O2
-android: QMAKE_CFLAGS_RELEASE -= -O3
-android: QMAKE_CFLAGS_RELEASE -= -Os
-
-
-#############################################################
 #################    ANDROID BUILD ONLY    #################
 ###########################################################
 


### PR DESCRIPTION
Some basic compiler functionality is dependendent on having
optimizations enabled.

There shouldn't be any issues with -O2, which is the default for qmake's
release builds.