### PR TITLE
Replace -lomp with -fopenmp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ matrix:
             - g++-7
             - gcc-7
             - libfftw3-dev
-            - libomp-dev
             - qt5-default
             - libusb-1.0-0-dev
       env:

--- a/Desktop_Interface/Labrador.pro
+++ b/Desktop_Interface/Labrador.pro
@@ -360,7 +360,7 @@ DISTFILES += \
     build_android/package_source/res/xml/device_filter.xml
 
 # Vincenzo added these to get multithreading on Unix fftw
-unix: LIBS += -lomp
+unix: LIBS += -fopenmp
 unix: LIBS += -lfftw3f_omp
 unix: LIBS += -lfftw3_threads
 macx: INCLUDEPATH += /usr/local/include

--- a/Desktop_Interface/Labrador.pro
+++ b/Desktop_Interface/Labrador.pro
@@ -360,7 +360,8 @@ DISTFILES += \
     build_android/package_source/res/xml/device_filter.xml
 
 # Vincenzo added these to get multithreading on Unix fftw
-unix: LIBS += -fopenmp
+unix:!macx: LIBS += -fopenmp
+macx: LIBS += -lomp
 unix: LIBS += -lfftw3f_omp
 unix: LIBS += -lfftw3_threads
 macx: INCLUDEPATH += /usr/local/include


### PR DESCRIPTION
On my machine, libomp is part of clang, and libgomp is part of gcc.  Using -fopenmp should let it choose the right (or at least the existing) library based on the compiler.