### PR TITLE
Simplify the waveform reading code

### DIFF
--- a/Desktop_Interface/ui_elements/espocombobox.cpp
+++ b/Desktop_Interface/ui_elements/espocombobox.cpp
@@ -5,59 +5,22 @@ espoComboBox::espoComboBox(QWidget *parent) : QComboBox(parent)
 
 }
 
-
 void espoComboBox::readWaveformList(void)
 {
-    //This code gets the name of the current directory, regardless of platform.
-    //This is so the interface knows where to find the waveform data
-    //QDir *dir = new QDir();
-    //qDebug() << dir->currentPath();
 #ifdef PLATFORM_ANDROID
-    QFile qt_list("assets:/waveforms/_list.wfl");
-    bool success = qt_list.open(QIODevice::ReadOnly | QIODevice::Text);
-    if(!success){
-        qFatal("Could not load _list.wfl");
-    }
-
-    char nameBuffer[255];
-    QStringList *newNames = new QStringList();
-
-    while (!qt_list.atEnd()) {
-        QByteArray line = qt_list.readLine();
-        strcpy(nameBuffer, line.data());
-        strtok(nameBuffer, "\n\r");
-        newNames->append(nameBuffer);
-        qDebug() << nameBuffer;
-    }
-    this->addItems(*(newNames));
-    delete newNames;
-    qt_list.close();
+    QFile file("assets:/waveforms/_list.wfl");
 #else
-    QString dirString = QCoreApplication::applicationDirPath();
-    dirString.append("/waveforms/_list.wfl");
-    QByteArray array = dirString.toLocal8Bit();
-    char* buffer = array.data();
-    //qDebug() << buffer;
-
-    qDebug() << "Attempting to open" << dirString;
-
-    FILE *listPtr = fopen(buffer, "r");
-    QStringList *newNames = new QStringList();
-    char nameBuffer[255];
-
-    if(listPtr == NULL){
-        qFatal("Could not load _list.wfl");
-    }
-
-    while (fgets(nameBuffer, sizeof(nameBuffer), listPtr) != NULL){
-        qDebug() << "nameBuffer = " << nameBuffer;
-        strtok(nameBuffer, "\n\r");
-        newNames->append(nameBuffer);
-    }
-    this->addItems(*(newNames));
-    delete newNames;
-
-    fclose(listPtr);
+    QString path = QCoreApplication::applicationDirPath();
+    QFile file(path.append("/waveforms/_list.wfl"));
 #endif
-    qDebug() << "List loaded!!";
+
+    qDebug() << "opening" << file.fileName();
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        qFatal("could not open %s", qUtf8Printable(file.fileName()));
+
+    QStringList newNames;
+    while (!file.atEnd())
+        newNames.append(file.readLine().trimmed());
+    this->addItems(newNames);
+    file.close();
 }


### PR DESCRIPTION
Combine the Android and non-Android implementations.  Only difference
now is the path to the waveform data.

Remove arbitrarily-sized buffers and most C-style string handling
function calls.  Use native Qt string methods instead; this should
improve memory safety.