### PR TITLE
Add get_digital_data_sincelast to librador

### DIFF
--- a/Librador_API/___librador/librador_shared_library/librador.cpp
+++ b/Librador_API/___librador/librador_shared_library/librador.cpp
@@ -119,6 +119,26 @@ std::vector<double> * librador_get_analog_data_sincelast(int channel, double tim
 
 }
 
+std::vector<uint8_t> * librador_get_digital_data_sincelast(int channel, double timeWindow_max_seconds, double sample_rate_hz, double delay_seconds){
+    VECTOR_API_INIT_CHECK
+    VECTOR_USB_INIT_CHECK
+
+    double subsamples_per_second = internal_librador_object->usb_driver->get_samples_per_second() * 8;
+
+    if(subsamples_per_second == 0){
+        return NULL;
+    }
+
+
+    int interval_subsamples = round(subsamples_per_second / sample_rate_hz);
+    int feasible_window_end = round(delay_seconds * subsamples_per_second);
+    int feasible_window_begin = round((delay_seconds + timeWindow_max_seconds) * subsamples_per_second);
+
+    printf("interval_subsamples = %d\nfeasible_window_end = %d\nfeasible_window_begin = %d\n", interval_subsamples, feasible_window_end, feasible_window_begin);
+
+    return internal_librador_object->usb_driver->getMany_singleBit_sincelast(channel, feasible_window_begin, feasible_window_end, interval_subsamples);
+}
+
 
 int librador_reset_usb(){
     CHECK_API_INITIALISED

--- a/Librador_API/___librador/librador_shared_library/librador.h
+++ b/Librador_API/___librador/librador_shared_library/librador.h
@@ -42,6 +42,7 @@ uint8_t LIBRADORSHARED_EXPORT librador_get_device_firmware_variant();
 std::vector<double> * LIBRADORSHARED_EXPORT librador_get_analog_data(int channel, double timeWindow_seconds, double sample_rate_hz, double delay_seconds, int filter_mode);
 std::vector<double> * LIBRADORSHARED_EXPORT librador_get_analog_data_sincelast(int channel, double timeWindow_max_seconds, double sample_rate_hz, double delay_seconds, int filter_mode);
 std::vector<uint8_t> * LIBRADORSHARED_EXPORT librador_get_digital_data(int channel, double timeWindow_seconds, double sample_rate_hz, double delay_seconds);
+std::vector<uint8_t> * LIBRADORSHARED_EXPORT librador_get_digital_data_sincelast(int channel, double timeWindow_seconds, double sample_rate_hz, double delay_seconds);
 
 //TODO: flashFirmware();
 

--- a/Librador_API/___librador/librador_shared_library/o1buffer.cpp
+++ b/Librador_API/___librador/librador_shared_library/o1buffer.cpp
@@ -143,6 +143,54 @@ std::vector<uint8_t> *o1buffer::getMany_singleBit(int numToGet, int interval_sub
     return &convertedStream_digital;
 }
 
+std::vector<uint8_t> *o1buffer::getSinceLast_singleBit(int feasible_window_begin, int feasible_window_end, int interval_subsamples) {
+    //Calculate what sample the feasible window begins at
+    //printf_debugging("o1buffer::getSinceLast()\n")
+    int feasible_start_point = mostRecentAddress * 8 - feasible_window_begin;
+    if(feasible_start_point < 0){
+        feasible_start_point += NUM_SAMPLES_PER_CHANNEL * 8;
+    }
+
+    //Work out whether or not we're starting from the feasible window or the last point
+    int actual_start_point;
+    if(distanceFromMostRecentAddress(feasible_start_point / 8) > distanceFromMostRecentAddress(stream_index_at_last_call + interval_subsamples / 8)){
+        actual_start_point = stream_index_at_last_call * 8 + interval_subsamples;
+    } else {
+        actual_start_point = feasible_start_point;
+    }
+
+    //Work out how much we're copying
+    int actual_sample_distance = distanceFromMostRecentAddress(actual_start_point / 8) - distanceFromMostRecentAddress(mostRecentAddress - feasible_window_end / 8);
+    int numToGet = actual_sample_distance / interval_subsamples;
+    //printf_debugging("Fetching %d samples, starting at index %d with interval %d\n", numToGet, actual_start_point, interval_samples);
+
+    //Resize the vector
+    convertedStream_digital.resize(numToGet);
+
+    //Copy raw samples out.
+    int tempAddress;
+    int subsample_current_delay;
+    uint8_t mask;
+    uint8_t *data = convertedStream_digital.data();
+    int tempInt;
+
+    for(int i=0;i<numToGet;i++){
+        subsample_current_delay = actual_start_point + (interval_subsamples * i);
+        tempAddress = mostRecentAddress - subsample_current_delay / 8;
+        mask = 0x01 << (subsample_current_delay % 8);
+        if(tempAddress < 0){
+            tempAddress += NUM_SAMPLES_PER_CHANNEL;
+        }
+        tempInt = get(tempAddress);
+        data[i] = (((uint8_t)tempInt) & mask) ? 1 : 0;
+    }
+
+    //update stream_index_at_last_call for next call
+    stream_index_at_last_call = tempAddress;
+
+    return &convertedStream_digital;
+}
+
 std::vector<double> *o1buffer::getSinceLast(int feasible_window_begin, int feasible_window_end, int interval_samples, int filter_mode, double scope_gain, bool AC, bool twelve_bit_multimeter){
 
     //Calculate what sample the feasible window begins at

--- a/Librador_API/___librador/librador_shared_library/o1buffer.h
+++ b/Librador_API/___librador/librador_shared_library/o1buffer.h
@@ -25,6 +25,7 @@ public:
     std::vector<double> *getMany_double(int numToGet, int interval_samples, int delay_sample, int filter_mode, double scope_gain, bool AC, bool twelve_bit_multimeter);
     std::vector<uint8_t> *getMany_singleBit(int numToGet, int interval_subsamples, int delay_subsamples);
     std::vector<double> *getSinceLast(int feasible_window_begin, int feasible_window_end, int interval_samples, int filter_mode, double scope_gain, bool AC, bool twelve_bit_multimeter);
+    std::vector<uint8_t> *getSinceLast_singleBit(int feasible_window_begin, int feasible_window_end, int interval_subsamples);
     double vcc = 3.3;
     double frontendGain = (75.0/1075.0);
     double voltage_ref = 1.65;

--- a/Librador_API/___librador/librador_shared_library/usbcallhandler.cpp
+++ b/Librador_API/___librador/librador_shared_library/usbcallhandler.cpp
@@ -370,6 +370,26 @@ std::vector<double> *usbCallHandler::getMany_sincelast(int channel, int feasible
 
 }
 
+std::vector<uint8_t> * usbCallHandler::getMany_singleBit_sincelast(int channel, int feasible_window_begin, int feasible_window_end, int interval_subsamples){
+    std::vector<uint8_t>* temp_to_return = NULL;
+
+    buffer_read_write_mutex.lock();
+        switch(deviceMode){
+        case 1:
+            if(channel == 1) temp_to_return = internal_o1_buffer_375_CH2->getSinceLast_singleBit(feasible_window_begin, feasible_window_end, interval_subsamples);
+            break;
+        case 3:
+            if(channel == 1) temp_to_return = internal_o1_buffer_375_CH1->getSinceLast_singleBit(feasible_window_begin, feasible_window_end, interval_subsamples);
+            break;
+        case 4:
+            if(channel == 1) temp_to_return = internal_o1_buffer_375_CH1->getSinceLast_singleBit(feasible_window_begin, feasible_window_end, interval_subsamples);
+            else if (channel == 2) temp_to_return = internal_o1_buffer_375_CH2->getSinceLast_singleBit(feasible_window_begin, feasible_window_end, interval_subsamples);
+            break;
+        }
+    buffer_read_write_mutex.unlock();
+    return temp_to_return;
+}
+
 int usbCallHandler::send_device_reset(){
     libusb_reset_device(handle);
     return 0;

--- a/Librador_API/___librador/librador_shared_library/usbcallhandler.h
+++ b/Librador_API/___librador/librador_shared_library/usbcallhandler.h
@@ -68,6 +68,7 @@ public:
     std::vector<double> *getMany_double(int channel, int numToGet, int interval_samples, int delay_sample, int filter_mode);
     std::vector<uint8_t> * getMany_singleBit(int channel, int numToGet, int interval_subsamples, int delay_subsamples);
     std::vector<double> *getMany_sincelast(int channel, int feasible_window_begin, int feasible_window_end, int interval_samples, int filter_mode);
+    std::vector<uint8_t> * getMany_singleBit_sincelast(int channel, int feasible_window_begin, int feasible_window_end, int interval_subsamples);
     bool connected = false;
     //Control Commands
     int set_device_mode(int mode);


### PR DESCRIPTION
To mirror the `get_analog_data_sincelast` method on the digital side, I've added the function `get_digital_data_sincelast`.

I've made a mistake in the math that I have yet to identify -- it's not yet returning the right number of subsamples.  I will work that out and update this PR.

In the meantime, I thought I would open a draft here, to get your thoughts on adding this to the API.  Let me know what you think!