### PR TITLE
Make Librador logger configurable

### DIFF
--- a/Librador_API/___librador/librador_shared_library/librador.cpp
+++ b/Librador_API/___librador/librador_shared_library/librador.cpp
@@ -1,6 +1,7 @@
 #include "librador.h"
 #include "librador_internal.h"
 #include "usbcallhandler.h"
+#include "logging_internal.h"
 
 #include <vector>
 #include <math.h>
@@ -94,7 +95,7 @@ std::vector<uint8_t> * librador_get_digital_data(int channel, double timeWindow_
     int delay_subsamples = round(delay_seconds * subsamples_per_second);
     int numToGet = round(timeWindow_seconds * subsamples_per_second)/interval_subsamples;
 
-    printf("interval_subsamples = %d\ndelay_subsamples = %d\nnumToGet=%d\n", interval_subsamples, delay_subsamples, numToGet);
+    LIBRADOR_LOG(LOG_DEBUG, "interval_subsamples = %d\ndelay_subsamples = %d\nnumToGet=%d\n", interval_subsamples, delay_subsamples, numToGet);
 
     return internal_librador_object->usb_driver->getMany_singleBit(channel, numToGet, interval_subsamples, delay_subsamples);
 }
@@ -295,3 +296,15 @@ int librador_synchronise_end(){
     return internal_librador_object->usb_driver->set_synchronous_pause_state(false);
 }
 */
+
+void
+librador_global_logger(
+		const int level,
+		const char * format,
+		... )
+{
+	va_list args;
+	va_start(args, format);
+	vfprintf((level > LOG_ERROR) ?  stdout : stderr , format, args);
+	va_end(args);
+}

--- a/Librador_API/___librador/librador_shared_library/librador.cpp
+++ b/Librador_API/___librador/librador_shared_library/librador.cpp
@@ -297,14 +297,31 @@ int librador_synchronise_end(){
 }
 */
 
-void
-librador_global_logger(
-		const int level,
-		const char * format,
-		... )
-{
+static void std_logger(void * userdata, const int level, const char * format, va_list ap);
+static librador_logger_p _librador_global_logger = std_logger;
+static void * _librador_global_userdata = NULL;
+
+void librador_global_logger(const int level, const char * format, ...){
 	va_list args;
 	va_start(args, format);
-	vfprintf((level > LOG_ERROR) ?  stdout : stderr , format, args);
+	if (_librador_global_logger)
+		_librador_global_logger(_librador_global_userdata, level, format, args);
 	va_end(args);
+}
+
+void librador_logger_set(void * userdata, librador_logger_p logger){
+	_librador_global_logger = logger ? logger : std_logger;
+	_librador_global_userdata = userdata;
+}
+
+librador_logger_p librador_logger_get(void){
+	return _librador_global_logger;
+}
+
+void * librador_logger_get_userdata(void){
+	return _librador_global_userdata;
+}
+
+static void std_logger(void * userdata, const int level, const char * format, va_list ap){
+	vfprintf((level > LOG_ERROR) ?  stdout : stderr , format, ap);
 }

--- a/Librador_API/___librador/librador_shared_library/librador.h
+++ b/Librador_API/___librador/librador_shared_library/librador.h
@@ -2,7 +2,9 @@
 #define LIBRADOR_H
 
 #include "librador_global.h"
+#include "logging.h"
 #include <vector>
+#include <stdarg.h>
 #include <stdint.h>
 
 int LIBRADORSHARED_EXPORT librador_init();
@@ -51,6 +53,12 @@ std::vector<uint8_t> * LIBRADORSHARED_EXPORT librador_get_digital_data(int chann
 int LIBRADORSHARED_EXPORT librador_synchronise_begin();
 int LIBRADORSHARED_EXPORT librador_synchronise_end();
 */
+
+typedef void (*librador_logger_p)(void * userdata, const int level, const char * format, va_list);
+
+void LIBRADORSHARED_EXPORT librador_logger_set(void * userdata, librador_logger_p logger);
+librador_logger_p LIBRADORSHARED_EXPORT librador_logger_get(void);
+void * LIBRADORSHARED_EXPORT librador_logger_get_userdata(void);
 
 
 #endif // LIBRADOR_H

--- a/Librador_API/___librador/librador_shared_library/logging.h
+++ b/Librador_API/___librador/librador_shared_library/logging.h
@@ -1,0 +1,11 @@
+#ifndef LOGGING_H
+#define LOGGING_H
+
+enum {
+    LOG_NONE = 0,
+    LOG_ERROR,
+    LOG_WARNING,
+    LOG_DEBUG,
+};
+
+#endif // LOGGING_H

--- a/Librador_API/___librador/librador_shared_library/logging_internal.h
+++ b/Librador_API/___librador/librador_shared_library/logging_internal.h
@@ -1,0 +1,13 @@
+#ifndef LOGGING_INTERNAL_H
+#define LOGGING_INTERNAL_H
+
+#include "logging.h"
+
+#define LIBRADOR_LOG(level, ...) \
+    do { \
+        librador_global_logger(level, __VA_ARGS__); \
+    } while (0)
+
+void librador_global_logger(const int level, const char * format, ...);
+
+#endif // LOGGING_INTERNAL_H

--- a/Librador_API/___librador/librador_shared_library/o1buffer.cpp
+++ b/Librador_API/___librador/librador_shared_library/o1buffer.cpp
@@ -1,4 +1,5 @@
 #include "o1buffer.h"
+#include "logging_internal.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -34,7 +35,7 @@ void o1buffer::add(int value, int address){
         address = address % NUM_SAMPLES_PER_CHANNEL;
     }
     if(address<0){
-        fprintf(stderr, "ERROR: o1buffer::add was given a negative address\n");
+        LIBRADOR_LOG(LOG_ERROR, "ERROR: o1buffer::add was given a negative address\n");
     }
     //Assign the value
     buffer[address] = value;
@@ -88,7 +89,7 @@ int o1buffer::get(int address){
         address = address % NUM_SAMPLES_PER_CHANNEL;
     }
     if(address<0){
-        fprintf(stderr, "ERROR: o1buffer::get was given a negative address\n");
+        LIBRADOR_LOG(LOG_ERROR, "ERROR: o1buffer::get was given a negative address\n");
     }
     //Return the value
     return buffer[address];


### PR DESCRIPTION
This adds a layer of indirection to logging in Librador.  Rather than directly calling `(f)printf`, we call through a global logger that the user can override.

The basic structure of this logger is taken from similar code in simavr: https://github.com/buserror/simavr/blob/ea4c4504d15117223a23e2dd6edb745fea61ceae/simavr/sim/sim_avr.c#L40-L73