### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For the documentation, please visit:
 https://github.com/espotek/labrador/wiki 
 
 # Raspberry Pi Build
-***Please note that the Raspbian version 9 (Stretch) or later is required to install this software.***
+***Please note that the 32-bit version of Raspbian version 9 (Stretch) or later is required to install this software.***
 
 To install Labrador on the Raspberry Pi, open a terminal and paste the following command:  
 `wget -O /tmp/labrador_bootstrap_pi https://raw.githubusercontent.com/EspoTek/Labrador/master/labrador_bootstrap_pi && sudo chmod +x /tmp/labrador_bootstrap_pi && sudo /tmp/labrador_bootstrap_pi`


### PR DESCRIPTION
In light of #219, be explicit about requiring the 32-bit version of Raspbian in the README. The note is now the same as how it is presented in the [release for Raspberry Pi](https://github.com/EspoTek/Labrador/releases/tag/raspberry-pi-bootstrap).