### PR TITLE
Introducing duty cycle to the Square waveform

### DIFF
--- a/Desktop_Interface/functiongencontrol.cpp
+++ b/Desktop_Interface/functiongencontrol.cpp
@@ -133,6 +133,14 @@ void SingleChannelController::offsetUpdate(double newOffset)
 	notifyUpdate(this);
 }
 
+void SingleChannelController::dutyCycleUpdate(double newDutyCycle)
+{
+	qDebug() << "newDutyCycle = " << newDutyCycle;
+	m_data.dutyCycle = newDutyCycle;
+	m_data.repeat_forever = true;
+	notifyUpdate(this);
+}
+
 void SingleChannelController::txuartUpdate(int baudRate, std::vector<uint8_t> samples)
 {
 	// Update txUart data
@@ -214,6 +222,11 @@ void DualChannelController::offsetUpdate(ChannelID channelID, double newOffset)
 	getChannelController(channelID)->offsetUpdate(newOffset);
 }
 
+void DualChannelController::dutyCycleUpdate(ChannelID channelID, double newDutyCycle)
+{
+	getChannelController(channelID)->dutyCycleUpdate(newDutyCycle);
+}
+
 void DualChannelController::txuartUpdate(ChannelID channelID, int baudRate, std::vector<uint8_t> samples)
 {
 	getChannelController(channelID)->txuartUpdate(baudRate, samples);
@@ -250,6 +263,11 @@ void DualChannelController::offsetUpdate_CH1(double newOffset)
 	offsetUpdate(ChannelID::CH1, newOffset);
 }
 
+void DualChannelController::dutyCycleUpdate_CH1(double newDutyCycle)
+{
+	dutyCycleUpdate(ChannelID::CH1, newDutyCycle);
+}
+
 
 void DualChannelController::waveformName_CH2(QString newName)
 {
@@ -269,6 +287,11 @@ void DualChannelController::amplitudeUpdate_CH2(double newAmplitude)
 void DualChannelController::offsetUpdate_CH2(double newOffset)
 {
 	offsetUpdate(ChannelID::CH2, newOffset);
+}
+
+void DualChannelController::dutyCycleUpdate_CH2(double newDutyCycle)
+{
+    dutyCycleUpdate(ChannelID::CH2, newDutyCycle);
 }
 
 }

--- a/Desktop_Interface/functiongencontrol.h
+++ b/Desktop_Interface/functiongencontrol.h
@@ -30,6 +30,7 @@ struct ChannelData
 	double freq = 1000.0, freq2 = 1000.0;
 	double amplitude = 0.0;
 	double offset = 0.0;
+	double dutyCycle = 50;
 };
 
 class SingleChannelController : public QObject
@@ -49,6 +50,7 @@ public slots:
     void freqUpdate(double newFreq);
     void amplitudeUpdate(double newAmplitude);
     void offsetUpdate(double newOffset);
+    void dutyCycleUpdate(double newDutyCycle);
     void txuartUpdate(int baudRate, std::vector<uint8_t> samples);
     void backup_waveform();
     void restore_waveform();
@@ -81,16 +83,19 @@ public slots:
     void freqUpdate(ChannelID channelID, double newFreq);
     void amplitudeUpdate(ChannelID channelID, double newAmplitude);
     void offsetUpdate(ChannelID channelID, double newOffset);
+    void dutyCycleUpdate(ChannelID channelID, double newDutyCycle);
 
     void waveformName_CH1(QString newName);
     void freqUpdate_CH1(double newFreq);
     void amplitudeUpdate_CH1(double newAmplitude);
     void offsetUpdate_CH1(double newOffset);
+    void dutyCycleUpdate_CH1(double newDutyCycle);
 
     void waveformName_CH2(QString newName);
     void freqUpdate_CH2(double newFreq);
     void amplitudeUpdate_CH2(double newAmplitude);
     void offsetUpdate_CH2(double newOffset);
+    void dutyCycleUpdate_CH2(double newDutyCycle);
 
 private:
 	SingleChannelController m_channels[2];

--- a/Desktop_Interface/genericusbdriver.cpp
+++ b/Desktop_Interface/genericusbdriver.cpp
@@ -179,6 +179,20 @@ void genericUsbDriver::sendFunctionGenData(functionGen::ChannelID channelID)
     usbSendControl(0x40, 0xa4, fGenTriple, 0, 0, NULL);
 #endif
 
+    // Apply duty cycle to Square waveform
+    if(channelData.waveform == "Square")
+    {
+        int length = channelData.samples.size();
+        int dutyCycle = static_cast<int>((channelData.dutyCycle*length)/100);
+        for (int i = 0; i < length; ++i)
+        {
+            if(i < dutyCycle)
+                channelData.samples[i] = 255;
+            else
+                channelData.samples[i] = 0;
+        }
+    }
+
 	auto applyAmplitudeAndOffset = [&](unsigned char sample) -> unsigned char
 	{
 		return sample / 255.0 * channelData.amplitude + channelData.offset;

--- a/Desktop_Interface/ui_files_desktop/mainwindow.ui
+++ b/Desktop_Interface/ui_files_desktop/mainwindow.ui
@@ -1086,6 +1086,29 @@
                </property>
               </widget>
              </item>
+             <item row="5" column="0">
+              <widget class="QLabel" name="dutyCycleLabel_CH1">
+               <property name="text">
+                <string>Duty cycle</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="1">
+              <widget class="espoSpinBox" name="dutyCycleValue_CH1">
+               <property name="minimum">
+                <double>0.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>100.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>1.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>50.000000000000000</double>
+               </property>
+              </widget>
+             </item>
             </layout>
            </item>
           </layout>
@@ -1215,6 +1238,29 @@
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="0">
+              <widget class="QLabel" name="dutyCycleLabel_CH2">
+               <property name="text">
+                <string>Duty cycle</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <widget class="espoSpinBox" name="dutyCycleValue_CH2">
+               <property name="minimum">
+                <double>0.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>100.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>1.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>50.000000000000000</double>
                </property>
               </widget>
              </item>
@@ -4599,6 +4645,54 @@
     <hint type="destinationlabel">
      <x>985</x>
      <y>1126</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>dutyCycleValue_CH1</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>controller_fg</receiver>
+   <slot>dutyCycleUpdate_CH1(double)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>985</x>
+     <y>1136</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>411</x>
+     <y>477</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>dutyCycleValue_CH2</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>controller_fg</receiver>
+   <slot>dutyCycleUpdate_CH2(double)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>1225</x>
+     <y>1136</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>411</x>
+     <y>477</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>serialEncodingCheck_CH1</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>dutyCycleValue_CH1</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>1394</x>
+     <y>982</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>985</x>
+     <y>1136</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
This pull request adds duty cycle on the square waveform of Signal Gen CH1 and CH2.

Under the hood, the locally stored waveform data (**Square.tlw**)  is replaced by a  **duty-cycled** Square waveform and sent over to the board for waveform generation.

The duty cycle takes percentage values (0% - 100%)