### PR TITLE
added Makefile for firmware

### DIFF
--- a/AVR_Code/USB_BULK_TEST/Makefile
+++ b/AVR_Code/USB_BULK_TEST/Makefile
@@ -1,3 +1,4 @@
+# see https://github.com/espotek-org/Labrador/wiki/Building-from-source#building-the-firmware
 EXECUTABLES :=
 LIB_DEP :=
 LIBS :=


### PR DESCRIPTION
I wrote up a guide for compiling the firmware using gnu command line tools [here](https://github.com/espotek-org/Labrador/wiki/Building-from-source#building-the-firmware) in the wiki.  I think this is a nice ability to enable as it widens the pool of users who are able to customize the firmware.  The build requires a Makefile, which I included in this PR.