### PR TITLE
Simplify scroll zoom calculations

### DIFF
--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -354,14 +354,15 @@ void DisplayControl::setRespAndSpecRanges(QWheelEvent* event, QCustomPlot* axes,
     double steps = event->delta() / 120.0;
     if (!(event->modifiers() == Qt::ControlModifier) && event->orientation() == Qt::Orientation::Vertical) {
         QCPRange range = axes->yAxis->range();
-        double pixPct = 100.0 - (100.0 * (((double)axes->yAxis->pixelToCoord(event->y())-range.lower) / range.size()));
-        if (pixPct < 0.0) pixPct = 0.0;
-        if (pixPct > 100.0) pixPct = 100.0;
-        qDebug() << "WHEEL @" << pixPct << "%";
+        double offset = (double)axes->yAxis->pixelToCoord(event->y()) - range.lower;
+        offset /= range.size();
+        if (offset < 0.0) offset = 0.0;
+        if (offset > 1.0) offset = 1.0;
+        qDebug() << "WHEEL @" << offset * 100.0 << "%";
 
-        double scale = steps * range.size() / 400.0;
-        range.upper -= scale * pixPct;
-        range.lower += scale * (100.0 - pixPct);
+        double scale = steps * range.size() / 4.0;
+        range.upper -= scale * (1.0 - offset);
+        range.lower += scale * offset;
         if (range.upper > 90.0) range.upper = 90.0;
         if (range.lower < -90.0) range.lower = -90.0;
         topRange = range.upper;
@@ -371,35 +372,35 @@ void DisplayControl::setRespAndSpecRanges(QWheelEvent* event, QCustomPlot* axes,
         botRangeUpdated(botRange);
     } else {
         QCPRange range = axes->xAxis->range();
-        double pixPct;
-        if(axes->xAxis->scaleType()==QCPAxis::stLogarithmic) {
-            pixPct = 100.0 * (log((double)axes->xAxis->pixelToCoord(event->x())) - log(range.lower));
-            pixPct /= log(range.upper) - log(range.lower);
+        double offset;
+        if (axes->xAxis->scaleType() == QCPAxis::stLogarithmic) {
+            offset = log((double)axes->xAxis->pixelToCoord(event->x())) - log(range.lower);
+            offset /= log(range.upper) - log(range.lower);
         } else {
-            pixPct = 100.0 * ((double)axes->xAxis->pixelToCoord(event->x()) - range.lower);
-            pixPct /= range.size();
+            offset = (double)axes->xAxis->pixelToCoord(event->x()) - range.lower;
+            offset /= range.size();
         }
-        if (pixPct < 0.0) pixPct = 0.0;
-        if (pixPct > 100.0) pixPct = 100.0;
-        qDebug() << "WHEEL @" << pixPct << "%";
+        if (offset < 0.0) offset = 0.0;
+        if (offset > 1.0) offset = 1.0;
+        qDebug() << "WHEEL @" << offset * 100.0 << "%";
 
-        if(axes->xAxis->scaleType()==QCPAxis::stLogarithmic) {
+        if (axes->xAxis->scaleType() == QCPAxis::stLogarithmic) {
             double base = range.upper / range.lower;
-            range.upper *= pow(base, (-steps * (100.0-pixPct)/200.));
-            range.lower *= pow(base, (steps * pixPct)/200.);
+            range.upper *= pow(base, -steps * (1.0 - offset) / 2.0);
+            range.lower *= pow(base, steps * offset / 2.0);
             if (range.lower < 1.0) range.lower = 1.0;
         } else {
-            double scale = steps * range.size() / 200.0;
-            range.upper -= scale * (100.0 - pixPct);
-            range.lower += scale * pixPct;
-            qDebug() << scale * pixPct;
+            double scale = steps * range.size() / 2.0;
+            range.upper -= scale * (1.0 - offset);
+            range.lower += scale * offset;
+            qDebug() << scale * offset;
             if (range.lower < 0.0) range.lower = 0.0;
         }
         if (range.upper > 750.0e3) range.upper = 750.0e3;
         leftRange = range.lower;
         rightRange = range.upper;
 
-        if(axes->xAxis->scaleType()==QCPAxis::stLogarithmic) {
+        if (axes->xAxis->scaleType() == QCPAxis::stLogarithmic) {
             driver->retickXAxis();
         }
     }
@@ -413,15 +414,16 @@ void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused,
     double steps = event->delta() / 120.0;
     if (!(event->modifiers() == Qt::ControlModifier) && event->orientation() == Qt::Orientation::Vertical) {
         QCPRange range = axes->yAxis->range();
-        double pixPct = 100.0 - (100.0 * (((double)axes->yAxis->pixelToCoord(event->y())-range.lower) / range.size()));
-        if (pixPct < 0.0) pixPct = 0.0;
-        if (pixPct > 100.0) pixPct = 100.0;
-        qDebug() << "WHEEL @" << pixPct << "%";
+        double offset = (double)axes->yAxis->pixelToCoord(event->y()) - range.lower;
+        offset /= range.size();
+        if (offset < 0.0) offset = 0.0;
+        if (offset > 1.0) offset = 1.0;
+        qDebug() << "WHEEL @" << offset * 100.0 << "%";
         qDebug() << range.upper;
 
-        double scale = steps * (topRange - botRange) / 400.0;
-        topRange -= scale * pixPct;
-        botRange += scale * (100.0 - pixPct);
+        double scale = steps * (topRange - botRange) / 4.0;
+        topRange -= scale * (1.0 - offset);
+        botRange += scale * offset;
         if (topRange > 20.0) topRange = 20.0;
         if (botRange < -20.0) botRange = -20.0;
 
@@ -429,22 +431,22 @@ void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused,
         botRangeUpdated(botRange);
     } else {
         QCPRange range = axes->xAxis->range();
-        double pixPct = 100.0 * ((double)axes->xAxis->pixelToCoord(event->x()) - range.lower);
-        pixPct /= isProperlyPaused ? range.size() : window;
-        if (pixPct < 0.0) pixPct = 0.0;
-        if (pixPct > 100.0) pixPct = 100.0;
-        qDebug() << "WHEEL @" << pixPct << "%";
+        double offset = (double)axes->xAxis->pixelToCoord(event->x()) - range.lower;
+        offset /= isProperlyPaused ? range.size() : window;
+        if (offset < 0.0) offset = 0.0;
+        if (offset > 1.0) offset = 1.0;
+        qDebug() << "WHEEL @" << offset * 100.0 << "%";
 
-        double scale = steps * window / 200.0;
+        double scale = steps * window / 2.0;
         if (!isProperlyPaused) {
             qDebug() << "TIGGERED";
             qDebug() << "upper = " << range.upper << "lower = " << range.lower;
             qDebug() << "window = " << window;
-            qDebug() << scale * pixPct;
-            qDebug() << scale * (100.0 - pixPct) * pixPct / 100.0;
+            qDebug() << scale * offset;
+            qDebug() << scale * (1.0 - offset) * offset;
         }
-        window -= scale * pixPct;
-        delay += scale * (100.0 - pixPct) * pixPct / 100.0;
+        window -= scale * offset;
+        delay += scale * (1.0 - offset) * offset;
 
         // NOTE: delayUpdated and timeWindowUpdated are called more than once beyond here,
         // maybe they should only be called once at the end?


### PR DESCRIPTION
I'm finding the code and math behind the plot extent calculations hard to follow.  There are many casts to `(double)` which are mostly unnecessary, either the expression is already a double or it's an integer literal that we can replace with a floating-point literal.  There are several places where we multiply or divide by 100 and they often cancel out.  This PR cleans it up and removes many of the extra operations.  There should be no functional change.