### PR TITLE
Continuing #367 "Triggering at sig. gen. freq" with a cleaner file history

### DIFF
--- a/Desktop_Interface/genericusbdriver.cpp
+++ b/Desktop_Interface/genericusbdriver.cpp
@@ -253,6 +253,7 @@ void genericUsbDriver::sendFunctionGenData(functionGen::ChannelID channelID)
 			usbSendControl(0x40, 0xb2, timerPeriod, clkSetting, channelData.samples.size(), channelData.samples.data());
     }
 
+    this->sigGenFreqUpdated(channelID, clkSetting, timerPeriod, channelData.samples.size());
     return;
 
 }

--- a/Desktop_Interface/genericusbdriver.h
+++ b/Desktop_Interface/genericusbdriver.h
@@ -121,6 +121,7 @@ signals:
     void initialConnectComplete(void);
     void signalFirmwareFlash(void);
     void calibrateMe(void);
+    void sigGenFreqUpdated(functionGen::ChannelID channelID, int newClkSetting, int newTimerPeriod, int wfSize);
 public slots:
     void setPsu(double voltage);
     void setFunctionGen(functionGen::ChannelID channelID, functionGen::SingleChannelController *fGenControl);

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -27,7 +27,9 @@ enum class TriggerType : uint8_t
 {
     Disabled,
     Rising,
-    Falling
+    Falling,
+    CH1SigGen,
+    CH2SigGen
 };
 
 enum class TriggerSeekState : uint8_t
@@ -99,6 +101,7 @@ public:
     void setTriggerLevel(double voltageLevel, uint16_t top, bool acCoupled);
     double getDelayedTriggerPoint(double delay);
     double getTriggerFrequencyHz();
+    void setSigGenTriggerFreq(functionGen::ChannelID channelID, int clkSetting, int timerPeriod, int wfSize);
 
 // ---- MEMBER VARIABLES ----
 
@@ -154,11 +157,13 @@ private:
 	qulonglong m_fileIO_maxFileSize;
 	qulonglong m_fileIO_numBytesWritten;
 	unsigned int m_currentColumn = 0;
-    uint32_t m_lastTriggerDetlaT = 0;
+    double m_lastTriggerDeltaT = 0.0;
+    float bufferSamplesPerCH1WfCycle;
+    float bufferSamplesPerCH2WfCycle;
 
 	isoDriver* m_virtualParent;
 
-    void addTriggerPosition(uint32_t position);
+    void addTriggerPosition(uint32_t m_back, uint32_t position, int n_cycles);
 signals:
 	void fileIOinternalDisable();
 public slots:

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -806,6 +806,13 @@ void isoDriver::setTriggerLevel(double level)
     triggerStateChanged();
 }
 
+// channel ID here refers to the wf gen channels
+void isoDriver::newSigGenTriggerFreq(functionGen::ChannelID channelID, int clkSetting, int timerPeriod, int wfSize) {
+    internalBuffer375_CH1->setSigGenTriggerFreq(channelID, clkSetting, timerPeriod, wfSize);
+    internalBuffer750->setSigGenTriggerFreq(channelID, clkSetting, timerPeriod, wfSize);
+}
+
+
 void isoDriver::setSingleShotEnabled(bool enabled)
 {
     singleShotEnabled = enabled;
@@ -868,8 +875,10 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
     double triggerDelay = 0;
     if (triggerEnabled)
     {
-        triggerDelay = (triggerMode < 2) ? internalBuffer_CH1->getDelayedTriggerPoint(display->window) - display->window
-                                         : internalBuffer_CH2->getDelayedTriggerPoint(display->window) - display->window;
+        if((triggerMode<2)||(triggerMode>=4))
+            triggerDelay = internalBuffer_CH1->getDelayedTriggerPoint(display->window) - display->window;
+        else
+            triggerDelay = internalBuffer_CH2->getDelayedTriggerPoint(display->window) - display->window;
 
         if (triggerDelay < 0)
             triggerDelay = 0;
@@ -1728,7 +1737,7 @@ void isoDriver::slowTimerTick(){
     update_CH1 = true;
     update_CH2 = true;
 
-    bool frequencyLabelVisible = false;
+    bool frequencyLabelValid = false;
 
     if (triggerEnabled)
     {
@@ -1744,11 +1753,15 @@ void isoDriver::slowTimerTick(){
         case 3:
             triggerFrequency = internalBuffer375_CH2->getTriggerFrequencyHz();
             break;
+        case 4:
+        case 5:
+            triggerFrequency = (driver->deviceMode == 6) ? internalBuffer750->getTriggerFrequencyHz() : internalBuffer375_CH1->getTriggerFrequencyHz();
+            break;
         }
 
         if (triggerFrequency > 0.)
         {
-            frequencyLabelVisible = true;
+            frequencyLabelValid = true;
             siprint triggerFreqSiprint("Hz", triggerFrequency);
             siprint periodSiprint("s", 1. / triggerFrequency);
 
@@ -1758,7 +1771,7 @@ void isoDriver::slowTimerTick(){
         qDebug() << triggerFrequency << "Hz";
     }
 
-    triggerFrequencyLabel->setVisible(frequencyLabelVisible);
+    triggerFrequencyLabel->setVisible(showTriggerFrequencyLabel&&frequencyLabelValid);
 }
 
 void isoDriver::setTopRange(double newTop)
@@ -2047,6 +2060,7 @@ void isoDriver::triggerStateChanged()
 {
     if (!triggerEnabled)
     {
+
         internalBuffer375_CH1->setTriggerType(TriggerType::Disabled);
         internalBuffer375_CH2->setTriggerType(TriggerType::Disabled);
         internalBuffer750->setTriggerType(TriggerType::Disabled);
@@ -2085,6 +2099,23 @@ void isoDriver::triggerStateChanged()
             internalBuffer750->setTriggerType(TriggerType::Disabled);
             break;
         }
+    // use the CH1 buffer to do the sig gen trigger timekeeping.  If there were a Ch. 2-only mode for the device,
+    // this practice could be problematic, but at present there is no Ch. 2-only mode.
+    // Also, in CH#SigGen below, the channel number refers to the sig gen channel
+        case 4:
+        {
+            internalBuffer375_CH1->setTriggerType(TriggerType::CH1SigGen);
+            internalBuffer375_CH2->setTriggerType(TriggerType::Disabled);
+            internalBuffer750->setTriggerType(TriggerType::CH1SigGen);
+            break;
+        }
+        case 5:
+        {
+            internalBuffer375_CH1->setTriggerType(TriggerType::CH2SigGen);
+            internalBuffer375_CH2->setTriggerType(TriggerType::Disabled);
+            internalBuffer750->setTriggerType(TriggerType::CH2SigGen);
+        }
+
     }
 }
 

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -7,6 +7,7 @@
 #include <QVector>
 #include "qcustomplot.h"
 #include "genericusbdriver.h"
+#include "functiongencontrol.h"
 #include "desktop_settings.h"
 #include "siprint.h"
 #include "i2cdecoder.h"
@@ -54,6 +55,7 @@ signals:
     void botRangeUpdated(double);
     void timeWindowUpdated(double);
     void delayUpdated(double);
+
 };
 
 class isoDriver : public QLabel
@@ -71,6 +73,7 @@ public:
     QCPItemText *cursorLabel;
     QCPItemText *fSpaceLabel;
     QCPItemText *triggerFrequencyLabel;
+    bool showTriggerFrequencyLabel = true;
 #endif
     genericUsbDriver *driver;
     bool doNotTouchGraph = true;
@@ -153,7 +156,6 @@ private:
     bool firstFrame = true;
     bool hexDisplay_CH1 = false;
     bool hexDisplay_CH2 = false;
-
 
     //Generic Functions
     QVector<double> analogConvert(std::vector<short> &in, int TOP, bool AC, int channel);
@@ -330,6 +332,8 @@ public slots:
     void attenuationChanged_CH2(int attenuationIndex);
     void setHexDisplay_CH1(bool enabled);
     void setHexDisplay_CH2(bool enabled);
+
+    void newSigGenTriggerFreq(functionGen::ChannelID channelID, int clkSetting, int timerPeriod, int wfSize);
 #ifndef DISABLE_SPECTRUM
     void setWindowingType(int windowing);
     void setMinFreqResp(double minFreqResp);

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -166,6 +166,7 @@ MainWindow::MainWindow(QWidget *parent) :
         connect(ui->psuSlider, SIGNAL(voltageChanged(double)), ui->controller_iso->driver, SLOT(setPsu(double)));
         connect(ui->controller_iso, SIGNAL(setGain(double)), ui->controller_iso->driver, SLOT(setGain(double)));
         connect(ui->controller_fg, &functionGenControl::functionGenToUpdate, ui->controller_iso->driver, &genericUsbDriver::setFunctionGen);
+        connect(ui->controller_iso->driver, &genericUsbDriver::sigGenFreqUpdated, ui->controller_iso, &isoDriver::newSigGenTriggerFreq);
         connect(ui->bufferDisplay, SIGNAL(modeChange(int)), ui->controller_iso->driver, SLOT(setDeviceMode(int)));
 		connect(ui->bufferDisplay, &bufferControl::modeChange, this, [this](){
 			// Force a trigger refresh
@@ -1525,6 +1526,7 @@ void MainWindow::reinitUsbStage2(void){
     connect(ui->psuSlider, SIGNAL(voltageChanged(double)), ui->controller_iso->driver, SLOT(setPsu(double)));
     connect(ui->controller_iso, SIGNAL(setGain(double)), ui->controller_iso->driver, SLOT(setGain(double)));
     connect(ui->controller_fg, &functionGenControl::functionGenToUpdate, ui->controller_iso->driver, &genericUsbDriver::setFunctionGen);
+    connect(ui->controller_iso->driver, &genericUsbDriver::sigGenFreqUpdated, ui->controller_iso, &isoDriver::newSigGenTriggerFreq);
     connect(ui->bufferDisplay, SIGNAL(modeChange(int)), ui->controller_iso->driver, SLOT(setDeviceMode(int)));
 	connect(ui->bufferDisplay, &bufferControl::modeChange, this, [this](){
 		// Force a trigger refresh
@@ -2771,10 +2773,13 @@ void MainWindow::on_actionFrequency_Spectrum_triggered(bool checked)
         ui->scopeAxes->xAxis->setNumberFormat(defaultNumberFormat);
     }
 
-    if (checked == true)
+    if (checked == true) {
         MAX_WINDOW_SIZE = 1<<17;
-    else
+        ui->controller_iso->showTriggerFrequencyLabel = false;
+    } else {
         MAX_WINDOW_SIZE = 10;
+        ui->controller_iso->showTriggerFrequencyLabel = true;
+    }
 }
 
 void MainWindow::on_actionFrequency_Response_triggered(bool checked)
@@ -2808,6 +2813,7 @@ void MainWindow::on_actionFrequency_Response_triggered(bool checked)
         ui->cursorHoriCheck->setChecked(ui->controller_iso->horiCursorEnabled2);
         ui->cursorVertCheck->setChecked(ui->controller_iso->vertCursorEnabled2);
         ui->controller_iso->retickXAxis();
+        ui->controller_iso->showTriggerFrequencyLabel = false;
     }else{
         ui->cursorHoriCheck->setChecked(ui->controller_iso->horiCursorEnabled0);
         ui->cursorVertCheck->setChecked(ui->controller_iso->vertCursorEnabled0);
@@ -2817,6 +2823,7 @@ void MainWindow::on_actionFrequency_Response_triggered(bool checked)
         ui->scopeAxes->xAxis->setNumberPrecision(defaultNumberPrecision);
         ui->scopeAxes->xAxis->setAutoTickCount(defaultAutoTickCount);
         ui->scopeAxes->xAxis->setNumberFormat(defaultNumberFormat);
+        ui->controller_iso->showTriggerFrequencyLabel = true;
     }
 }
 
@@ -2847,9 +2854,11 @@ void MainWindow::on_actionEye_Diagram_triggered(bool checked)
     if(checked){
         ui->cursorHoriCheck->setChecked(ui->controller_iso->horiCursorEnabled3);
         ui->cursorVertCheck->setChecked(ui->controller_iso->vertCursorEnabled3);
+        ui->controller_iso->showTriggerFrequencyLabel = false;
     }else{
         ui->cursorHoriCheck->setChecked(ui->controller_iso->horiCursorEnabled0);
         ui->cursorVertCheck->setChecked(ui->controller_iso->vertCursorEnabled0);
+        ui->controller_iso->showTriggerFrequencyLabel = true;
     }
 }
 #endif
@@ -2945,6 +2954,25 @@ void MainWindow::on_serialEncodingCheck_CH1_toggled(bool checked)
         ui->controller_fg->restore_waveform(ChannelID::CH1);
     }
 }
+
+void MainWindow::triggerChannelChanged(int newTriggerChannel){
+    if((newTriggerChannel==4)||(newTriggerChannel==5)) {
+        ui->triggerLevelValue->setEnabled(false);
+        ui->singleShotCheckBox->setEnabled(false);
+        ui->singleShotCheckBox->setChecked(false);
+#ifndef PLATFORM_ANDROID
+        ui->label_6->setEnabled(false);
+#endif
+    } else {
+        ui->triggerLevelValue->setEnabled(true);
+        ui->singleShotCheckBox->setEnabled(true);
+#ifndef PLATFORM_ANDROID
+        ui->label_6->setEnabled(true);
+#endif
+    }
+}
+
+
 
 void MainWindow::on_txuart_textChanged()
 {

--- a/Desktop_Interface/mainwindow.h
+++ b/Desktop_Interface/mainwindow.h
@@ -66,6 +66,8 @@ private slots:
     void on_actionSnap_to_Cursors_triggered();
     void on_actionEnter_Manually_triggered();
 
+    void triggerChannelChanged(int newTriggerChannel);
+
     void connectDisplaySignals();
     void calibrateStage2();
     void calibrateStage3();

--- a/Desktop_Interface/ui_files_desktop/mainwindow.ui
+++ b/Desktop_Interface/ui_files_desktop/mainwindow.ui
@@ -691,6 +691,16 @@
                      <string>CH2 (Falling)</string>
                     </property>
                    </item>
+                   <item>
+                    <property name="text">
+                     <string>Sig. Gen. CH1</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Sig. Gen. CH2</string>
+                    </property>
+                   </item>
                   </widget>
                  </item>
                 </layout>
@@ -3642,6 +3652,12 @@
      <y>892</y>
     </hint>
    </hints>
+  </connection>
+  <connection>
+   <sender>triggerChannelSelect</sender>
+   <signal>currentIndexChanged(int)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>triggerChannelChanged(int)</slot>
   </connection>
   <connection>
    <sender>acCoupledLabel_CH1</sender>

--- a/Desktop_Interface/ui_files_mobile/mainwindow.ui
+++ b/Desktop_Interface/ui_files_mobile/mainwindow.ui
@@ -576,6 +576,16 @@
                      <string>CH2 (Falling)</string>
                     </property>
                    </item>
+                   <item>
+                    <property name="text">
+                     <string>Sig. Gen. CH1</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Sig. Gen. CH2</string>
+                    </property>
+                   </item>
                   </widget>
                  </item>
                  <item>
@@ -3626,6 +3636,12 @@
      <y>757</y>
     </hint>
    </hints>
+  </connection>
+  <connection>
+   <sender>triggerChannelSelect</sender>
+   <signal>currentIndexChanged(int)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>triggerChannelChanged(int)</slot>
   </connection>
   <connection>
    <sender>acCoupledLabel_CH1</sender>


### PR DESCRIPTION
Added new trigger type options, Sig. Gen. Ch1 and Ch2 , that set the trigger frequency equal to the respective sig. gen. frequencies. In these modes, there's no need to adjust the trigger level to get the waveform steady on the screen.  The feature gets finicky above \~25 khz or so, especially when 'scope channel 2 is enabled. I've dug around trying to find a cause, but haven't had any luck yet. The issue only appears in a limited operating range (>~ 25 khz), is not all that common even in that range, and can usually be resolved by disabling/enabling 'scope channel 2, so imo isn't a huge demerit for the PR.  Also, #288 is fixed in this PR.