### PR TITLE
Workflow for avr build

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -1,0 +1,60 @@
+name: Build firmware
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      variant:
+        type: string
+        description: 'variant: 01, 02, or leave the field blank to build both variants'
+        required: false
+
+  push:
+    branches:
+      - master
+      - main
+
+  pull_request:
+    branches:
+      - master
+      - main
+
+jobs:
+  build-hex:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name : Checkout repository
+        uses: actions/checkout@v4
+       
+      - name : make 01
+        if: ((github.event_name == 'push') || (github.event_name == 'pull_request') || ((github.event_name == 'workflow_dispatch') && ((inputs.variant == '') || (inputs.variant == '01'))))
+        uses: bazhenov/action-avr-make@v1.1
+        with:
+          dir: AVR_Code/USB_BULK_TEST
+          target: '01'
+
+      - name : make mostlyclean
+        if: ((github.event_name == 'push') || (github.event_name == 'pull_request') || ((github.event_name == 'workflow_dispatch') && (inputs.variant == '')))
+        uses: bazhenov/action-avr-make@v1.1
+        with:
+          dir: AVR_Code/USB_BULK_TEST
+          target: mostlyclean
+
+      - name : make 02
+        if: ((github.event_name == 'push') || (github.event_name == 'pull_request') || ((github.event_name == 'workflow_dispatch') && ((inputs.variant == '') || (inputs.variant == '02'))))
+        uses: bazhenov/action-avr-make@v1.1
+        with:
+          dir: AVR_Code/USB_BULK_TEST
+          target: '02'
+
+      - name: Upload hex artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: asset-hex
+          path: AVR_Code/USB_BULK_TEST/labrafirm*.hex
+          compression-level: 0
+          if-no-files-found: error


### PR DESCRIPTION
(Following up on some of the discussion in #381.)
This PR:
- adds a workflow (firmware.yml) for the firmware
- makes edits to continuous.yml:
  - adds a firmware compilation job
  - adds support for the mac build scheme described in the bullet below
- revises mac.yml so that:
    - when mac.yml is called by continuous.yml, the firmware .hex asset produced by continuous.yml is packaged into the mac desktop interface
    - when mac.yml is called in some other context, the firmware .hex asset produced by the most recent call to continuous.yml is packaged into the desktop interface
- and similarly for the other platforms' workflows

The versioning is centralized, but not automatic.  Namely, the current version of the firmware has to be set in .github/actions/define-firmware-ver-action/action.yml.  At compile time, the firmware version defined there gets injected:
- into AVR_Code/.../src/main.c as the macro FIRMWARE_VERSION_ID, which previously was defined in AVR_Code/.../src/globals.h
- into the desktop interface as the macro EXPECTED_FIRMWARE_VERSION, which previously was defined in Desktop_Interface/genericusbdriver.h

Also, the inclusion of the version number in the .hex file names has been retained, so they are, e.g., labrafirm_0007_0{1 or 2}.hex.  To me, this is worthwhile because then the firmware that's packaged into a given release can be very easily determined.
