### PR TITLE
move librador isoCallback mutex positions

### DIFF
--- a/Librador_API/___librador/librador/usbcallhandler.cpp
+++ b/Librador_API/___librador/librador/usbcallhandler.cpp
@@ -53,10 +53,10 @@ o1buffer *internal_o1_buffer_750;
 static void LIBUSB_CALL isoCallback(struct libusb_transfer * transfer){
     //Thread mutex??
     //printf("Copy the data...\n");
+    buffer_read_write_mutex.lock();
     for(int i=0;i<transfer->num_iso_packets;i++){
         unsigned char *packetPointer = libusb_get_iso_packet_buffer_simple(transfer, i);
         //TODO: a switch statement here to handle all the modes.
-        buffer_read_write_mutex.lock();
         switch(deviceMode){
         case 0:
             internal_o1_buffer_375_CH1->addVector((char*) packetPointer, 375);
@@ -83,8 +83,8 @@ static void LIBUSB_CALL isoCallback(struct libusb_transfer * transfer){
             internal_o1_buffer_375_CH1->addVector((short*) packetPointer, 375);
             break;
         }
-        buffer_read_write_mutex.unlock();
     }
+    buffer_read_write_mutex.unlock();
     //printf("Re-arm the endpoint...\n");
     if(usb_iso_needs_rearming()){
         int error = libusb_submit_transfer(transfer);


### PR DESCRIPTION
This PR for librador changes the position of the mutex lock/unlock in usbcallhandler.cpp->`isoCallback(...)` such that the mutex stays locked for an entire USB transfer's worth of data (33 packets) instead of only a single packet.  For context, `isoCallback` gets called by libusb when a USB transfer is ready and proceeds to read in the new data to usbcallhandler.cpp.
Justification:
	Say a front-end gui is operating at 60 fps and so is requesting data from usbcallhandler.cpp every 17 ms.  If one of these requests comes when `buffer_read_write_mutex` is locked by `isoCallback`, then the request waits until the mutex gets unlocked.  If it gets unlocked after every packet, the request then accesses all data up to that most recent packet and finishes.
	The gui then won't request data again for another 17 ms.  However, at the time of the original request, all packets of the most recent USB transfer are available but simply haven't yet been added to usbcallhandler's buffers by `isoCallback`.  This process takes only something like a millisecond.  This PR's repositioning of the mutex lock/unlock in `isoCallback` trades this 1 ms delay for the 17 ms delay.