### PR TITLE
Zoom gesture changes

### DIFF
--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -389,11 +389,12 @@ void DisplayControl::setRespAndSpecRanges(QWheelEvent* event, QCustomPlot* axes,
         range.lower += scale * offset;
         if (range.upper > 90.0) range.upper = 90.0;
         if (range.lower < -90.0) range.lower = -90.0;
-        topRange = range.upper;
-        botRange = range.lower;
-
-        topRangeUpdated(topRange);
-        botRangeUpdated(botRange);
+        if( (range.upper - range.lower) > 1.e-4) {
+            topRange = range.upper;
+            botRange = range.lower;
+            topRangeUpdated(topRange);
+            botRangeUpdated(botRange);
+        }
     } else {
         QCPRange range = axes->xAxis->range();
         double offset;
@@ -421,11 +422,12 @@ void DisplayControl::setRespAndSpecRanges(QWheelEvent* event, QCustomPlot* axes,
             if (range.lower < 0.0) range.lower = 0.0;
         }
         if (range.upper > 750.0e3) range.upper = 750.0e3;
-        leftRange = range.lower;
-        rightRange = range.upper;
-
-        if (axes->xAxis->scaleType() == QCPAxis::stLogarithmic) {
-            driver->retickXAxis();
+        if((range.upper - range.lower) > 1.e-3) {
+            leftRange = range.lower;
+            rightRange = range.upper;
+            if (axes->xAxis->scaleType() == QCPAxis::stLogarithmic) {
+                driver->retickXAxis();
+            }
         }
     }
 }
@@ -446,13 +448,17 @@ void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused,
         qDebug() << range.upper;
 
         double scale = steps * (topRange - botRange) / 4.0;
-        topRange -= scale * (1.0 - offset);
-        botRange += scale * offset;
-        if (topRange > 20.0) topRange = 20.0;
-        if (botRange < -20.0) botRange = -20.0;
+        range.upper -= scale * (1.0 - offset);
+        range.lower += scale * offset;
+        if (range.upper > 20.0) range.upper = 20.0;
+        if (range.lower < -20.0) range.lower = -20.0;
+        if( (range.upper - range.lower) > 1.e-6) {
+            topRange = range.upper;
+            botRange = range.lower;
+            topRangeUpdated(topRange);
+            botRangeUpdated(botRange);
+        }
 
-        topRangeUpdated(topRange);
-        botRangeUpdated(botRange);
     } else {
         QCPRange range = axes->xAxis->range();
         double offset = (double)axes->xAxis->pixelToCoord(event->x()) - range.lower;
@@ -467,7 +473,7 @@ void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused,
             qDebug() << "upper = " << range.upper << "lower = " << range.lower;
             qDebug() << "window = " << window;
             qDebug() << scale * offset;
-            qDebug() << scale * (1.0 - offset) * offset;
+            qDebug() << scale * (1.0 - offset);
         }
 
         double lower = delay;
@@ -478,11 +484,12 @@ void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused,
             lower = 0;
         if(upper > MAX_WINDOW_SIZE)
             upper = MAX_WINDOW_SIZE;
-        window = upper - lower;
-        delay = lower;
-
-        delayUpdated(delay);
-        timeWindowUpdated(window);
+        if ((upper - lower) > 1.e-9) {
+            window = upper - lower;
+            delay = lower;
+            delayUpdated(delay);
+            timeWindowUpdated(window);
+        }
     }
 }
 

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -469,32 +469,20 @@ void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused,
             qDebug() << scale * offset;
             qDebug() << scale * (1.0 - offset) * offset;
         }
-        window -= scale * offset;
-        delay += scale * (1.0 - offset) * offset;
 
-        // NOTE: delayUpdated and timeWindowUpdated are called more than once beyond here,
-        // maybe they should only be called once at the end?
+        double lower = delay;
+        double upper = delay + window;
+        lower += scale * (1.0 - offset);
+        upper -= scale * offset;
+        if(lower < 0)
+            lower = 0;
+        if(upper > MAX_WINDOW_SIZE)
+            upper = MAX_WINDOW_SIZE;
+        window = upper - lower;
+        delay = lower;
 
         delayUpdated(delay);
         timeWindowUpdated(window);
-
-        qDebug() << window << delay;
-
-        if (window > maxWindowSize)
-        {
-            window = maxWindowSize;
-            timeWindowUpdated(window);
-        }
-        if ((window + delay) > maxWindowSize)
-        {
-            delay = maxWindowSize - window;
-            delayUpdated(delay);
-        }
-        if (delay < 0)
-        {
-            delay = 0;
-            delayUpdated(delay);
-        }
     }
 }
 


### PR DESCRIPTION
~~This PR changes the zoom gestures so that they're possibly more intuitive when a trackpad is used.  Specifically, placing the cursor on the l.h.s. of the screen and swiping left moves the graph leftward below the edge, and similarly for the r.h.s as well as the top and the bottom.  Placing the cursor in the middle 1/2 of the screen and swiping left/right zooms the screen out/in while keeping the data value of the exact center of the screen constant, and similarly for swiping down/up.
One drawback is that these new gestures no longer keep the x/y value hovered by the mouse constant during the zoom, which the current gestures do.  Such behavior is especially appealing for pinch gestures on android, for which the effective mouse position is the center of the user's fingers.  So, this PR includes preprocessor directives such that the PR has no effect on the android app.~~