### PR TITLE
revisit d7bdf69: preventing mode 5 from being sent to the board (#439)

### DIFF
--- a/Desktop_Interface/genericusbdriver.cpp
+++ b/Desktop_Interface/genericusbdriver.cpp
@@ -376,7 +376,7 @@ void genericUsbDriver::setGain(double newGain){
     */
     qDebug("newGain = %f", newGain);
     qDebug("gainMask = %x", gainMask);
-    usbSendControl(0x40, 0xa5, (deviceMode == 5 ? 0 : 5), gainMask, 0, NULL);
+    usbSendControl(0x40, 0xa5, (deviceMode == 5 ? 0 : deviceMode), gainMask, 0, NULL);
 }
 
 void genericUsbDriver::avrDebug(void){


### PR DESCRIPTION
#439 had the right idea but the wrong execution.  My bad.  This PR gets it right.