### PR TITLE
break out of dfu_make_idle retry loop upon success

### DIFF
--- a/libdfuprog/libdfuprog.c
+++ b/libdfuprog/libdfuprog.c
@@ -190,9 +190,11 @@ int dfuprog_virtual_main(int argc, char **argv)
     dfu_device.interface = interface;
 
     int retries = 6;
-    while (retries > 0) {
+    dfu_bool made_idle = false;
+    while (retries > 0 && made_idle == false) {
         switch (dfu_make_idle(&dfu_device, args.initial_abort)) {
             case 0:
+                made_idle = true;
                 break;
             case 1:
                 retries--;


### PR DESCRIPTION
This PR fixes a bug in the Android-specific stage of firmware flashing that runs `dfu_make_idle`.  Both pre-PR and in the PR, a loop is used to allow for retries in case the `dfu_make_idle` call fails.  However, in the pre-PR code, the loop isn't broken when `dfu_make_idle` is successful.  In the PR, the bool `made_idle` is used to break the loop upon success.  It seems that standard bools aren't available for the adopted C dialect, so I used the `dfu_bool` type from `dfu-programmer`.

I figure I'll also take this opportunity to document that the first call to `dfu_make_idle` fails with `status->bStatus: errSTALLEDPKT (0x0f)` and `status->bState: dfuERROR`, but the second try goes through just fine, flashing proceeds, and the firmware gets successfully uploaded.
